### PR TITLE
[Feat#67] 파일 개별 삭제 구현

### DIFF
--- a/src/main/java/com/back/domain/files/files/controller/FilesController.java
+++ b/src/main/java/com/back/domain/files/files/controller/FilesController.java
@@ -4,8 +4,10 @@ import com.back.domain.files.files.dto.FileUploadResponseDto;
 import com.back.domain.files.files.service.FilesService;
 import com.back.domain.member.service.MemberService;
 import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,9 +22,10 @@ public class FilesController {
     private final MemberService memberService;
 
     // 파일 업로드 (게시글 저장 -> postId 받음, 이미지 저장)
-    @PostMapping("/{postId}/files")
+    @PostMapping(value = "/{postId}/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public RsData<List<FileUploadResponseDto>> uploadFiles(
             @PathVariable @Positive long postId,
+            @Parameter (description = "업로드할 파일들", required = false)
             @RequestPart(value = "files", required = false) MultipartFile[] files
     ) {
         return filesService.uploadFiles(postId, files);

--- a/src/main/java/com/back/domain/files/files/controller/FilesController.java
+++ b/src/main/java/com/back/domain/files/files/controller/FilesController.java
@@ -2,6 +2,7 @@ package com.back.domain.files.files.controller;
 
 import com.back.domain.files.files.dto.FileUploadResponseDto;
 import com.back.domain.files.files.service.FilesService;
+import com.back.domain.member.service.MemberService;
 import com.back.global.rsData.RsData;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import java.util.List;
 public class FilesController {
 
     private final FilesService filesService;
+    private final MemberService memberService;
 
     // 파일 업로드 (게시글 저장 -> postId 받음, 이미지 저장)
     @PostMapping("/{postId}/files")
@@ -32,4 +34,14 @@ public class FilesController {
         return filesService.getFilesByPostId(postId);
     }
 
+    // 파일 삭제
+    @DeleteMapping("/{postId}/files/{fileId}")
+    public RsData<Void> deleteFile(
+            @PathVariable @Positive long postId,
+            @PathVariable @Positive long fileId
+
+    ) {
+        Long memberId = 1L; // 테스트
+        return filesService.deleteFile(postId, fileId, memberId);
+    }
 }

--- a/src/main/java/com/back/domain/files/files/repository/FilesRepository.java
+++ b/src/main/java/com/back/domain/files/files/repository/FilesRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface FilesRepository extends JpaRepository<Files, Long> {
     List<Files> findByPostIdOrderBySortOrderAsc(Long postId);
-
+    Optional<Files> findById(Long fileId);
+    void delete(Files file);
 }

--- a/src/main/java/com/back/domain/files/files/service/FilesService.java
+++ b/src/main/java/com/back/domain/files/files/service/FilesService.java
@@ -107,10 +107,10 @@ public class FilesService {
         Files file = filesRepository.findById(fileId)
                 .orElseThrow(() -> new IllegalArgumentException("파일이 존재하지 않습니다: " + fileId));
 
-        if (!(file.getPost().getId() == postId)) {
+        if (!file.getPost().getId().equals(postId)) {
             throw new IllegalArgumentException("해당 게시글에 속하지 않는 파일입니다: " + fileId);
         }
-        if (!(file.getPost().getMember().getId() == memberId)) {
+        if (!file.getPost().getMember().getId().equals(memberId)) {
             throw new IllegalArgumentException("해당 파일을 삭제할 권한이 없습니다. " + memberId);
         }
 

--- a/src/main/java/com/back/domain/files/files/service/FilesService.java
+++ b/src/main/java/com/back/domain/files/files/service/FilesService.java
@@ -98,4 +98,24 @@ public class FilesService {
                 result
         );
     }
+
+
+    // 파일 개별 삭제 서비스
+    public RsData<Void> deleteFile(Long postId, Long fileId, Long memberId) {
+        // TODO: 실제 로그인한 회원 ID는 스프링 시큐리티나 Rq.getActor().getId()에서 받아야 함
+
+        Files file = filesRepository.findById(fileId)
+                .orElseThrow(() -> new IllegalArgumentException("파일이 존재하지 않습니다: " + fileId));
+
+        if (!(file.getPost().getId() == postId)) {
+            throw new IllegalArgumentException("해당 게시글에 속하지 않는 파일입니다: " + fileId);
+        }
+        if (!(file.getPost().getMember().getId() == memberId)) {
+            throw new IllegalArgumentException("해당 파일을 삭제할 권한이 없습니다. " + memberId);
+        }
+
+        filesRepository.deleteById(fileId);
+        return new RsData("200", "파일 삭제 성공", null);
+    }
+
 }

--- a/src/test/java/com/back/domain/files/files/controller/FilesControllerTest.java
+++ b/src/test/java/com/back/domain/files/files/controller/FilesControllerTest.java
@@ -21,8 +21,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -104,7 +103,7 @@ public class FilesControllerTest {
     @Test
     @DisplayName("파일 조회 성공 - 파일 있음")
     @WithMockUser(username = "test-user", roles = "USER")
-    void testGetFilesByPostId_Success() throws Exception {
+    void t3() throws Exception {
         long postId = 5L;
 
         List<FileUploadResponseDto> fileList = List.of(
@@ -139,7 +138,7 @@ public class FilesControllerTest {
     @Test
     @DisplayName("파일 조회 - 파일 없음(빈 파일, 정상)")
     @WithMockUser(username = "test-user", roles = "USER")
-    void testGetFilesByPostId_Empty() throws Exception {
+    void t4() throws Exception {
         long postId = 5L;
 
         RsData<List<FileUploadResponseDto>> rsData = new RsData<>(
@@ -158,5 +157,26 @@ public class FilesControllerTest {
                 .andExpect(jsonPath("$.data").isEmpty());
     }
 
+    @Test
+    @DisplayName("파일 삭제 성공")
+    @WithMockUser(username = "test-user", roles = "USER")
+    void t5() throws Exception {
+        long postId = 5L;
+        long fileId = 1L;
+
+        RsData<Void> rsData = new RsData<>(
+                "200",
+                "파일 삭제 성공",
+                null
+        );
+
+        // filesService.deleteFile 호출 시 응답 설정
+        given(filesService.deleteFile(postId, fileId, 1L)).willReturn(rsData); // memberId는 1L로 고정됨
+
+        mockMvc.perform(delete("/api/posts/{postId}/files/{fileId}", postId, fileId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200"))
+                .andExpect(jsonPath("$.msg").value("파일 삭제 성공"));
+    }
 
 }


### PR DESCRIPTION
## 📢 기능 설명
- 파일 개별 삭제 구현
- Long형에 맞게 코드 수정
필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #67 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [✅  ] PR 제목 규칙 잘 지켰는가?
- [✅  ] 추가/수정사항을 설명하였는가?
- [✅  ] 이슈넘버를 적었는가?
- [✅  ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 게시글에 첨부된 파일을 삭제할 수 있는 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 파일 삭제 시 게시글 소유자 확인 및 권한 검증이 강화되었습니다.

* **테스트**
  * 파일 삭제 기능에 대한 테스트가 추가되었습니다.
  * 기존 테스트 메서드명이 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->