### PR TITLE
[refactor] 로그인 로직 테스트 및 로그인 상태조회 기능 추가

### DIFF
--- a/src/main/java/com/back/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/controller/AuthController.java
@@ -3,19 +3,20 @@ package com.back.domain.auth.controller;
 import com.back.domain.auth.dto.request.MemberLoginRequest;
 import com.back.domain.auth.dto.request.MemberSignupRequest;
 import com.back.domain.auth.dto.response.MemberLoginResponse;
+import com.back.domain.member.dto.response.MemberInfoResponse;
+import com.back.domain.member.entity.Member;
 import com.back.domain.member.service.MemberService;
 import com.back.global.rsData.ResultCode;
 import com.back.global.rsData.RsData;
+import com.back.global.security.auth.MemberDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -57,5 +58,20 @@ public class AuthController {
                     .status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new RsData<>(ResultCode.SERVER_ERROR, "서버 오류가 발생했습니다."));
         }
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "로그인 사용자 정보 조회", description = "유효한 JWT 토큰을 통해 현재 인증된 사용자 정보를 조회합니다.")
+    public ResponseEntity<RsData<MemberInfoResponse>> me(Authentication authentication) {
+        MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
+        Member member = memberDetails.getMember();
+        if (member == null) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new RsData<>(ResultCode.UNAUTHORIZED, "로그인된 사용자가 없습니다."));
+        }
+        MemberInfoResponse response = MemberInfoResponse.fromEntity(member);
+
+        return ResponseEntity.ok(new RsData<>(ResultCode.GET_ME_SUCCESS, "로그인 사용자 정보 조회 성공", response));
     }
 }

--- a/src/main/java/com/back/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/controller/AuthController.java
@@ -63,13 +63,13 @@ public class AuthController {
     @GetMapping("/me")
     @Operation(summary = "로그인 사용자 정보 조회", description = "유효한 JWT 토큰을 통해 현재 인증된 사용자 정보를 조회합니다.")
     public ResponseEntity<RsData<MemberInfoResponse>> me(Authentication authentication) {
-        MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
-        Member member = memberDetails.getMember();
-        if (member == null) {
+        if (authentication == null || !(authentication.getPrincipal() instanceof MemberDetails memberDetails)) {
             return ResponseEntity
                     .status(HttpStatus.UNAUTHORIZED)
                     .body(new RsData<>(ResultCode.UNAUTHORIZED, "로그인된 사용자가 없습니다."));
         }
+
+        Member member = memberDetails.getMember();
         MemberInfoResponse response = MemberInfoResponse.fromEntity(member);
 
         return ResponseEntity.ok(new RsData<>(ResultCode.GET_ME_SUCCESS, "로그인 사용자 정보 조회 성공", response));

--- a/src/main/java/com/back/global/rsData/ResultCode.java
+++ b/src/main/java/com/back/global/rsData/ResultCode.java
@@ -5,6 +5,7 @@ public enum ResultCode {
     // 200: 성공
     LOGIN_SUCCESS("200-1", 200, "로그인 성공"),
     SIGNUP_SUCCESS("200-2", 200, "회원가입 성공"),
+    GET_ME_SUCCESS("200-3", 200, "사용자 정보 조회 성공"),
 
     // 400: 클라이언트 오류
     INVALID_REQUEST("400-1", 400, "요청 오류"),

--- a/src/main/java/com/back/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 경로들
-                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/api/auth/signup", "/api/auth/login").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
 
                         // Swagger 관련 경로들 - 더 구체적으로 설정

--- a/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
@@ -1,6 +1,5 @@
-package com.back.domain.auth;
+package com.back.domain.auth.controller;
 
-import com.back.domain.auth.controller.AuthController;
 import com.back.domain.auth.dto.request.MemberLoginRequest;
 import com.back.domain.auth.dto.request.MemberSignupRequest;
 import com.back.domain.auth.dto.response.MemberLoginResponse;
@@ -8,22 +7,36 @@ import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.domain.member.service.MemberService;
 import com.back.global.rsData.ResultCode;
 import com.back.global.rsData.RsData;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@SpringBootTest
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
+@AutoConfigureMockMvc
+@Transactional
 @DisplayName("AuthController 테스트")
 public class AuthControllerTest {
 
@@ -32,6 +45,12 @@ public class AuthControllerTest {
 
     @Mock
     private MemberService memberService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("회원가입 성공")
@@ -78,7 +97,7 @@ public class AuthControllerTest {
         // given
         MemberLoginRequest request = new MemberLoginRequest("test@example.com", "password123!");
         MemberLoginResponse response = new MemberLoginResponse("jwtToken",
-                "jwtRefreshToken",     new MemberInfoResponse(
+                "jwtRefreshToken", new MemberInfoResponse(
                 1L,
                 "test@example.com",
                 "홍길동",
@@ -97,6 +116,33 @@ public class AuthControllerTest {
         assertThat(rs.data().accessToken()).isEqualTo("jwtToken");
 
         verify(memberService, times(1)).login(request);
+    }
+
+    @Test
+    @DisplayName("JWT 로그인 성공 및 보호된 엔드포인트 접근")
+    void login_and_access_protected_endpoint() throws Exception {
+        // given
+        MemberLoginRequest request = new MemberLoginRequest("user1@user.com", "user1234!");
+
+        // 로그인 요청
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseJson = loginResult.getResponse().getContentAsString();
+
+        // 제네릭 타입 정보 주면서 파싱
+        RsData<Map<String, Object>> rsData = objectMapper.readValue(responseJson,
+                new TypeReference<RsData<Map<String, Object>>>() {});
+
+        String accessToken = rsData.data().get("accessToken").toString();
+
+        // 보호된 API 접근 (예: /auth/me)
+        mockMvc.perform(get("/api/auth/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
     }
 
     @Test


### PR DESCRIPTION
## 📢 기능 설명
1. 로그인 로직 테스트 코드 리팩토링
2. 로그인 조회 기능 추가
3. swagger및 postman에서 이제 회원가입/로그인/로그인조회 테스트 가능

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #75 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증된 사용자의 정보를 반환하는 `/api/auth/me` 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 인증 관련 엔드포인트의 접근 권한이 강화되어, 이제 `/api/auth/signup` 및 `/api/auth/login`만 인증 없이 접근할 수 있습니다.

* **테스트**
  * 로그인 후 보호된 엔드포인트에 접근하는 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->