### PR TITLE
[feat] 로그아웃 기능 구현, 추후 리팩토링 필요

### DIFF
--- a/src/main/java/com/back/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/controller/AuthController.java
@@ -43,6 +43,7 @@ public class AuthController {
         }
     }
 
+    // 로그인 API
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     public ResponseEntity<RsData<MemberLoginResponse>> login(@Valid @RequestBody MemberLoginRequest request) {
@@ -60,6 +61,7 @@ public class AuthController {
         }
     }
 
+    // 로그인 사용자 정보 조회 API
     @GetMapping("/me")
     @Operation(summary = "로그인 사용자 정보 조회", description = "유효한 JWT 토큰을 통해 현재 인증된 사용자 정보를 조회합니다.")
     public ResponseEntity<RsData<MemberInfoResponse>> me(Authentication authentication) {
@@ -73,5 +75,21 @@ public class AuthController {
         MemberInfoResponse response = MemberInfoResponse.fromEntity(member);
 
         return ResponseEntity.ok(new RsData<>(ResultCode.GET_ME_SUCCESS, "로그인 사용자 정보 조회 성공", response));
+    }
+
+    // 로그아웃 API
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "현재 로그인된 사용자의 refresh 토큰을 삭제합니다.")
+    public ResponseEntity<RsData<Void>> logout(Authentication authentication) {
+        if (authentication == null || !(authentication.getPrincipal() instanceof MemberDetails memberDetails)) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new RsData<>(ResultCode.UNAUTHORIZED, "로그인된 사용자가 없습니다."));
+        }
+
+        Member member = memberDetails.getMember();
+        memberService.logout(member);
+
+        return ResponseEntity.ok(new RsData<>(ResultCode.LOGOUT_SUCCESS, "로그아웃 성공", null));
     }
 }

--- a/src/main/java/com/back/domain/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/entity/Member.java
@@ -53,4 +53,9 @@ public class Member extends BaseEntity {
         this.status = (status != null) ? status : Status.ACTIVE;   // 기본 상태는 ACTIVE
     }
 
+    // 리프레시 토큰을 삭제(무효화)함
+    public void removeRefreshToken() {
+        this.refreshToken = null;
+    }
+
 }

--- a/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/service/MemberService.java
@@ -64,4 +64,11 @@ public class MemberService {
         // 4. DTO 응답 반환
         return new MemberLoginResponse(accessToken, refreshToken, MemberInfoResponse.fromEntity(member));
     }
+
+    // 로그아웃
+    @Transactional
+    public void logout(Member member) {
+        member.removeRefreshToken();
+        memberRepository.save(member);
+    }
 }

--- a/src/main/java/com/back/global/init/TestDataInitializer.java
+++ b/src/main/java/com/back/global/init/TestDataInitializer.java
@@ -30,7 +30,6 @@ public class TestDataInitializer implements ApplicationRunner {
     }
 
     // 일반 사용자 계정 생성
-    @Transactional
     public void initUser() {
         createUserIfNotExists("testuser1@user.com", "사용자1");
         createUserIfNotExists("testuser2@user.com", "사용자2");

--- a/src/main/java/com/back/global/rsData/ResultCode.java
+++ b/src/main/java/com/back/global/rsData/ResultCode.java
@@ -6,6 +6,7 @@ public enum ResultCode {
     LOGIN_SUCCESS("200-1", 200, "로그인 성공"),
     SIGNUP_SUCCESS("200-2", 200, "회원가입 성공"),
     GET_ME_SUCCESS("200-3", 200, "사용자 정보 조회 성공"),
+    LOGOUT_SUCCESS("200-4", 200, "로그아웃 성공"),
 
     // 400: 클라이언트 오류
     INVALID_REQUEST("400-1", 400, "요청 오류"),

--- a/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
@@ -2,24 +2,22 @@ package com.back.domain.auth.controller;
 
 import com.back.domain.auth.dto.request.MemberLoginRequest;
 import com.back.domain.auth.dto.request.MemberSignupRequest;
-import com.back.domain.auth.dto.response.MemberLoginResponse;
-import com.back.domain.member.dto.response.MemberInfoResponse;
-import com.back.domain.member.service.MemberService;
+import com.back.domain.member.entity.Member;
+import com.back.domain.member.entity.Role;
+import com.back.domain.member.entity.Status;
+import com.back.domain.member.repository.MemberRepository;
 import com.back.global.rsData.ResultCode;
 import com.back.global.rsData.RsData;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -27,24 +25,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @Transactional
-@DisplayName("AuthController 테스트")
+@DisplayName("AuthController 통합 테스트")
 public class AuthControllerTest {
-
-    @InjectMocks
-    private AuthController authController;
-
-    @Mock
-    private MemberService memberService;
 
     @Autowired
     private MockMvc mockMvc;
@@ -52,75 +44,99 @@ public class AuthControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Test
-    @DisplayName("회원가입 성공")
-    void signup_success() {
-        // given
-        MemberSignupRequest request = new MemberSignupRequest("test@example.com", "securePass123!", "홍길동");
+    // 테스트 데이터 삽입용 의존성 (예시)
+    @Autowired
+    private MemberRepository memberRepository;
 
-        // doNothing 설정: memberService.signup()이 예외를 던지지 않음
-        doNothing().when(memberService).signup(request);
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
-        // when
-        ResponseEntity<RsData<String>> response = authController.signup(request);
-        RsData<String> rs = response.getBody();
+    @BeforeEach
+    void setup() {
+        // JWT 로그인 테스트용 계정 추가
+        Member member = Member.builder()
+                .email("user1@user.com")
+                .password(passwordEncoder.encode("user1234!")) // 암호화 필수
+                .name("Test User")
+                .role(Role.USER)
+                .status(Status.ACTIVE)
+                .build();
 
-        // then
-        assertThat(rs.resultCode()).isEqualTo(ResultCode.SIGNUP_SUCCESS.code());
-        assertThat(rs.msg()).isEqualTo(ResultCode.SIGNUP_SUCCESS.message());
-
-        // memberService.signup()이 정확히 한 번 호출되었는지 확인
-        verify(memberService, times(1)).signup(request);
+        memberRepository.save(member);
     }
 
     @Test
-    @DisplayName("회원가입 실패 - 서버 오류")
-    void signup_exception() {
+    @DisplayName("회원가입 성공")
+    void signup_success() throws Exception {
         // given
-        MemberSignupRequest request = new MemberSignupRequest("test@example.com", "pass123!", "홍길동");
+        MemberSignupRequest request = new MemberSignupRequest("test@example.com", "securePass123!", "홍길동");
 
-        // 예외 던지기
-        doThrow(new RuntimeException("회원가입 중 오류")).when(memberService).signup(request);
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-2"))  // ResultCode에 맞게 수정
+                .andExpect(jsonPath("$.msg").value("회원가입 성공"));
+    }
 
-        // when
-        ResponseEntity<RsData<String>> response = authController.signup(request);
+    @Test
+    @DisplayName("회원가입 실패 - 이메일 중복")
+    void signup_email_duplicate() throws Exception {
+        // given
+        Member existing = Member.builder()
+                .email("test@example.com")
+                .password(passwordEncoder.encode("somepass!"))
+                .name("기존유저")
+                .role(Role.USER)
+                .status(Status.ACTIVE)
+                .build();
+        memberRepository.save(existing);
 
-        // then
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(response.getBody().resultCode()).isEqualTo(ResultCode.SERVER_ERROR.code());
-        assertThat(response.getBody().msg()).isEqualTo("서버 오류가 발생했습니다.");
+        MemberSignupRequest request = new MemberSignupRequest("test@example.com", "anotherPass123!", "홍길동");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultCode").value("400-1")) // 예: 이메일 중복 오류 코드
+                .andExpect(jsonPath("$.msg").value("이미 사용 중인 이메일입니다."));
     }
 
     @Test
     @DisplayName("로그인 성공")
-    void login_success() {
+    void login_success() throws Exception {
         // given
-        MemberLoginRequest request = new MemberLoginRequest("test@example.com", "password123!");
-        MemberLoginResponse response = new MemberLoginResponse("jwtToken",
-                "jwtRefreshToken", new MemberInfoResponse(
-                1L,
-                "test@example.com",
-                "홍길동",
-                "USER",
-                "https://example.com/profile.jpg"
-        ));
-
-        when(memberService.login(request)).thenReturn(response);
+        MemberLoginRequest request = new MemberLoginRequest("user1@user.com", "user1234!");
 
         // when
-        ResponseEntity<RsData<MemberLoginResponse>> result = authController.login(request);
-        RsData<MemberLoginResponse> rs = result.getBody();
-
-        // then
-        assertThat(rs.resultCode()).isEqualTo(ResultCode.LOGIN_SUCCESS.code());
-        assertThat(rs.msg()).isEqualTo("로그인 성공");
-        assertThat(rs.data().accessToken()).isEqualTo("jwtToken");
-
-        verify(memberService, times(1)).login(request);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1")) // 로그인 성공 코드
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andReturn();
     }
 
     @Test
-    @DisplayName("JWT 로그인 성공 및 보호된 엔드포인트 접근")
+    @DisplayName("로그인 실패 - 잘못된 비밀번호")
+    void login_invalid_credentials() throws Exception {
+        // given
+        MemberLoginRequest request = new MemberLoginRequest("user1@user.com", "wrongPassword!");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("401-3"))
+                .andExpect(jsonPath("$.msg").value("이메일 또는 비밀번호가 잘못되었습니다."));
+    }
+
+    @Test
+    @DisplayName("JWT 로그인 성공 후 보호된 엔드포인트 접근")
     void login_and_access_protected_endpoint() throws Exception {
         // given
         MemberLoginRequest request = new MemberLoginRequest("user1@user.com", "user1234!");
@@ -134,50 +150,53 @@ public class AuthControllerTest {
 
         String responseJson = loginResult.getResponse().getContentAsString();
 
-        // 제네릭 타입 정보 주면서 파싱
         RsData<Map<String, Object>> rsData = objectMapper.readValue(responseJson,
                 new TypeReference<RsData<Map<String, Object>>>() {});
 
         String accessToken = rsData.data().get("accessToken").toString();
 
-        // 보호된 API 접근 (예: /auth/me)
+        // 보호된 API 접근
         mockMvc.perform(get("/api/auth/me")
                         .header("Authorization", "Bearer " + accessToken))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.email").value("user1@user.com"));
     }
 
     @Test
-    @DisplayName("로그인 실패 - ID 혹은 비밀번호가 잘못되었거나 등록되지 않은 계정")
-    void login_invalidCredentials() {
-        // given
-        MemberLoginRequest request = new MemberLoginRequest("wrong@example.com", "wrongPassword");
+    @DisplayName("JWT 로그인 후 로그아웃 성공")
+    void login_and_logout_success() throws Exception {
+        // given - 로그인 요청
+        MemberLoginRequest loginRequest = new MemberLoginRequest("user1@user.com", "user1234!");
 
-        when(memberService.login(request)).thenThrow(new BadCredentialsException("잘못된 로그인"));
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
 
-        // when
-        ResponseEntity<RsData<MemberLoginResponse>> result = authController.login(request);
+        String loginResponseJson = loginResult.getResponse().getContentAsString();
 
-        // then
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
-        assertThat(result.getBody().resultCode()).isEqualTo(ResultCode.INVALID_CREDENTIALS.code());
-        assertThat(result.getBody().msg()).isEqualTo("이메일 또는 비밀번호가 잘못되었습니다.");
+        RsData<Map<String, Object>> loginRsData = objectMapper.readValue(
+                loginResponseJson, new TypeReference<RsData<Map<String, Object>>>() {});
+
+        String accessToken = loginRsData.data().get("accessToken").toString();
+
+        // when - 로그아웃 요청
+        MvcResult logoutResult = mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String logoutResponseJson = logoutResult.getResponse().getContentAsString();
+        RsData<Void> logoutRsData = objectMapper.readValue(
+                logoutResponseJson, new TypeReference<RsData<Void>>() {});
+
+        // then - 로그아웃 응답 검증
+        assertThat(logoutRsData.resultCode()).isEqualTo(ResultCode.LOGOUT_SUCCESS.code());
+        assertThat(logoutRsData.msg()).isEqualTo("로그아웃 성공");
+
+        // 로그아웃 후 refreshToken 제거되었는지 확인
+        Member member = memberRepository.findByEmail("user1@user.com").orElseThrow();
+        assertThat(member.getRefreshToken()).isNull();
     }
-
-    @Test
-    @DisplayName("로그인 실패 - 서버 오류")
-    void login_serverError() {
-        // given
-        MemberLoginRequest request = new MemberLoginRequest("test@example.com", "password123!");
-
-        when(memberService.login(request)).thenThrow(new RuntimeException("서버 내부 오류"));
-
-        // when
-        ResponseEntity<RsData<MemberLoginResponse>> result = authController.login(request);
-
-        // then
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(result.getBody().resultCode()).isEqualTo(ResultCode.SERVER_ERROR.code());
-        assertThat(result.getBody().msg()).isEqualTo("서버 오류가 발생했습니다.");
-    }
-
 }


### PR DESCRIPTION
## 📢 기능 설명
1. 로그인시 멤버 Entity에 저장된 RefreshToken을 삭제(null로 바꿔버림) 하는 로그아웃 로직 추가

<<문제점 발생>>
1. 로그인시 멤버 Entity에 RefreshToken이 저장되지 않은 버그를 발견함
2. 로그인 기능 버그 수정이 필요함

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #89 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 로그아웃 API 엔드포인트가 추가되어 사용자가 안전하게 로그아웃할 수 있습니다.

* **버그 수정**
  * 없음

* **테스트**
  * 인증 및 회원가입, 로그인, 로그아웃, 보호된 엔드포인트 접근에 대한 통합 테스트가 추가 및 개선되었습니다.

* **기타**
  * 일부 주석 및 메시지가 추가되어 API 사용성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->