### PR TITLE
[fix] 리프레시 토큰 저장 메서드 누락 오류 수정

### DIFF
--- a/src/main/java/com/back/domain/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/entity/Member.java
@@ -58,4 +58,9 @@ public class Member extends BaseEntity {
         this.refreshToken = null;
     }
 
+    // 리프레시 토큰을 설정함
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
 }

--- a/src/main/java/com/back/domain/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/entity/Member.java
@@ -60,6 +60,10 @@ public class Member extends BaseEntity {
 
     // 리프레시 토큰을 설정함
     public void updateRefreshToken(String refreshToken) {
+        // 유효성 검사: 리프레시 토큰이 null 또는 빈 문자열이 아닌지 확인
+        if (refreshToken == null || refreshToken.trim().isEmpty()) {
+            throw new IllegalArgumentException("리프레시 토큰은 null 또는 빈 문자열일 수 없습니다.");
+        }
         this.refreshToken = refreshToken;
     }
 

--- a/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/service/MemberService.java
@@ -61,7 +61,11 @@ public class MemberService {
         String accessToken = jwtTokenProvider.generateAccessToken(member);
         String refreshToken = jwtTokenProvider.generateRefreshToken(member);
 
-        // 4. DTO 응답 반환
+        // 4. 리프레시 토큰 저장
+        member.updateRefreshToken(refreshToken);
+        memberRepository.save(member);
+
+        // 5. DTO 응답 반환
         return new MemberLoginResponse(accessToken, refreshToken, MemberInfoResponse.fromEntity(member));
     }
 

--- a/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/service/MemberService.java
@@ -7,9 +7,13 @@ import com.back.domain.auth.dto.response.MemberLoginResponse;
 import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
+import com.back.global.exception.ServiceException;
+import com.back.global.rsData.ResultCode;
 import com.back.global.security.auth.MemberDetails;
 import com.back.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -19,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -63,7 +68,13 @@ public class MemberService {
 
         // 4. 리프레시 토큰 저장
         member.updateRefreshToken(refreshToken);
-        memberRepository.save(member);
+        try {
+            memberRepository.save(member);
+        } catch (DataIntegrityViolationException e) {
+            // 리프레시 토큰이 중복되는 경우, 기존 토큰을 업데이트
+            log.warn("중복된 refreshToken 저장 시도: {}", refreshToken);
+            throw new ServiceException(ResultCode.SERVER_ERROR.code(), "중복된 리프레시 토큰입니다.");
+        }
 
         // 5. DTO 응답 반환
         return new MemberLoginResponse(accessToken, refreshToken, MemberInfoResponse.fromEntity(member));

--- a/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
@@ -105,7 +105,7 @@ public class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("로그인 성공")
+    @DisplayName("로그인 성공(서비스만)")
     void login_success() throws Exception {
         // given
         MemberLoginRequest request = new MemberLoginRequest("user1@user.com", "user1234!");
@@ -180,6 +180,10 @@ public class AuthControllerTest {
                 loginResponseJson, new TypeReference<RsData<Map<String, Object>>>() {});
 
         String accessToken = loginRsData.data().get("accessToken").toString();
+
+        // 로그인 직후 refreshToken이 설정되었는지 확인
+        Member memberAfterLogin = memberRepository.findByEmail("user1@user.com").orElseThrow();
+        assertThat(memberAfterLogin.getRefreshToken()).isNotNull();
 
         // when - 로그아웃 요청
         MvcResult logoutResult = mockMvc.perform(post("/api/auth/logout")


### PR DESCRIPTION
## 📢 기능 설명
1. Member 엔티티에서  refreshToken을 설정하는 updateRefreshToken 메서드 선언
2. 서비스에서 로그인 로직에 RefreshToken을 저장하는 코드(빼먹었었음) 추가

=> 
member.updateRefreshToken(refreshToken);
memberRepository.save(member);

필요시 실행결과 스크린샷 첨부
<img width="1238" height="285" alt="image" src="https://github.com/user-attachments/assets/17f5c8df-28f6-46d0-89e6-fcdeec81324b" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #92 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그인 시 멤버의 리프레시 토큰이 데이터베이스에 저장됩니다.
  * 리프레시 토큰 저장 시 중복 저장에 대한 오류 처리가 추가되었습니다.

* **버그 수정**
  * 로그인 후 리프레시 토큰이 정상적으로 저장되는지 테스트가 추가되었습니다.

* **테스트**
  * 로그인 성공 테스트의 이름이 변경되었으며, 로그인 직후 리프레시 토큰 저장 여부를 검증하는 절차가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->