### PR TITLE
[refactor] MemberService, AuthService 분리

### DIFF
--- a/src/main/java/com/back/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.back.domain.auth.controller;
 import com.back.domain.auth.dto.request.MemberLoginRequest;
 import com.back.domain.auth.dto.request.MemberSignupRequest;
 import com.back.domain.auth.dto.response.MemberLoginResponse;
+import com.back.domain.auth.service.AuthService;
 import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.service.MemberService;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final MemberService memberService;
+    private final AuthService authService;
 
     // 회원가입 API
     @PostMapping("/signup")
@@ -48,7 +50,7 @@ public class AuthController {
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     public ResponseEntity<RsData<MemberLoginResponse>> login(@Valid @RequestBody MemberLoginRequest request) {
         try {
-            MemberLoginResponse response = memberService.login(request);
+            MemberLoginResponse response = authService.login(request);
             return ResponseEntity.ok(new RsData<>(ResultCode.LOGIN_SUCCESS, "로그인 성공", response));
         } catch (BadCredentialsException e) {
             return ResponseEntity
@@ -88,7 +90,7 @@ public class AuthController {
         }
 
         Member member = memberDetails.getMember();
-        memberService.logout(member);
+        authService.logout(member);
 
         return ResponseEntity.ok(new RsData<>(ResultCode.LOGOUT_SUCCESS, "로그아웃 성공", null));
     }

--- a/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -28,6 +28,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
     // 로그인
+    @Transactional
     public MemberLoginResponse login(MemberLoginRequest request) {
         // 1. 인증 시도
         UsernamePasswordAuthenticationToken authToken =
@@ -48,9 +49,9 @@ public class AuthService {
         try {
             memberRepository.save(member);
         } catch (DataIntegrityViolationException e) {
-            // 리프레시 토큰이 중복되는 경우, 기존 토큰을 업데이트
-            log.warn("중복된 refreshToken 저장 시도: {}", refreshToken);
-            throw new ServiceException(ResultCode.SERVER_ERROR.code(), "중복된 리프레시 토큰입니다.");
+            // 리프레시 토큰 저장 실패 시 재시도 또는 예외 처리
+            log.error("리프레시 토큰 저장 실패", e);
+            throw new ServiceException(ResultCode.SERVER_ERROR.code(), "토큰 저장에 실패했습니다.");
         }
 
         // 5. DTO 응답 반환

--- a/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -1,0 +1,66 @@
+package com.back.domain.auth.service;
+
+import com.back.domain.auth.dto.request.MemberLoginRequest;
+import com.back.domain.auth.dto.response.MemberLoginResponse;
+import com.back.domain.member.dto.response.MemberInfoResponse;
+import com.back.domain.member.entity.Member;
+import com.back.domain.member.repository.MemberRepository;
+import com.back.global.exception.ServiceException;
+import com.back.global.rsData.ResultCode;
+import com.back.global.security.auth.MemberDetails;
+import com.back.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 로그인
+    public MemberLoginResponse login(MemberLoginRequest request) {
+        // 1. 인증 시도
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(request.email(), request.password());
+
+        Authentication authentication = authenticationManager.authenticate(authToken);
+
+        // 2. 인증 성공시 사용자 정보 로드 (authentication에서 직접 꺼내기)
+        MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
+        Member member = memberDetails.getMember();
+
+        // 3. JWT 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(member);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(member);
+
+        // 4. 리프레시 토큰 저장
+        member.updateRefreshToken(refreshToken);
+        try {
+            memberRepository.save(member);
+        } catch (DataIntegrityViolationException e) {
+            // 리프레시 토큰이 중복되는 경우, 기존 토큰을 업데이트
+            log.warn("중복된 refreshToken 저장 시도: {}", refreshToken);
+            throw new ServiceException(ResultCode.SERVER_ERROR.code(), "중복된 리프레시 토큰입니다.");
+        }
+
+        // 5. DTO 응답 반환
+        return new MemberLoginResponse(accessToken, refreshToken, MemberInfoResponse.fromEntity(member));
+    }
+
+    // 로그아웃
+    @Transactional
+    public void logout(Member member) {
+        member.removeRefreshToken();
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/service/MemberService.java
@@ -1,22 +1,11 @@
 package com.back.domain.member.service;
 
 
-import com.back.domain.auth.dto.request.MemberLoginRequest;
 import com.back.domain.auth.dto.request.MemberSignupRequest;
-import com.back.domain.auth.dto.response.MemberLoginResponse;
-import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
-import com.back.global.exception.ServiceException;
-import com.back.global.rsData.ResultCode;
-import com.back.global.security.auth.MemberDetails;
-import com.back.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,8 +17,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    private final AuthenticationManager authenticationManager;
-    private final JwtTokenProvider jwtTokenProvider;
 
 
     // 회원 가입
@@ -47,43 +34,6 @@ public class MemberService {
                 .name(request.name())
                 .build();
 
-        memberRepository.save(member);
-    }
-
-    // 로그인
-    public MemberLoginResponse login(MemberLoginRequest request) {
-        // 1. 인증 시도
-        UsernamePasswordAuthenticationToken authToken =
-                new UsernamePasswordAuthenticationToken(request.email(), request.password());
-
-        Authentication authentication = authenticationManager.authenticate(authToken);
-
-        // 2. 인증 성공시 사용자 정보 로드 (authentication에서 직접 꺼내기)
-        MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
-        Member member = memberDetails.getMember();
-
-        // 3. JWT 생성
-        String accessToken = jwtTokenProvider.generateAccessToken(member);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(member);
-
-        // 4. 리프레시 토큰 저장
-        member.updateRefreshToken(refreshToken);
-        try {
-            memberRepository.save(member);
-        } catch (DataIntegrityViolationException e) {
-            // 리프레시 토큰이 중복되는 경우, 기존 토큰을 업데이트
-            log.warn("중복된 refreshToken 저장 시도: {}", refreshToken);
-            throw new ServiceException(ResultCode.SERVER_ERROR.code(), "중복된 리프레시 토큰입니다.");
-        }
-
-        // 5. DTO 응답 반환
-        return new MemberLoginResponse(accessToken, refreshToken, MemberInfoResponse.fromEntity(member));
-    }
-
-    // 로그아웃
-    @Transactional
-    public void logout(Member member) {
-        member.removeRefreshToken();
         memberRepository.save(member);
     }
 }


### PR DESCRIPTION
## 📢 기능 설명
1. 로그인, 로그아웃과 같은 인증/토큰 처리는 AuthService로 분리
2. 회원가입, 회원 정보 수정/삭제와 같은 처리는 MemberService에서 관리

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #98 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증 관련 로그인 및 로그아웃 기능이 별도의 인증 서비스로 분리되었습니다.

* **버그 수정**
  * 기존 회원 서비스에서 로그인 및 로그아웃 관련 처리가 제거되어, 인증 흐름이 보다 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->