### PR TITLE
[feat] AccessToken 재발급 기능 구현

### DIFF
--- a/src/main/java/com/back/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/controller/AuthController.java
@@ -100,14 +100,22 @@ public class AuthController {
     // Access Token 재발급 API
     @PostMapping("/reissue")
     @Operation(summary = "AccessToken 재발급", description = "RefreshToken으로 AccessToken을 재발급 받습니다.")
-    public ResponseEntity<RsData<TokenReissueResponse>> reissue(@RequestBody TokenReissueRequest request) {
+    public ResponseEntity<RsData<TokenReissueResponse>> reissue(@Valid @RequestBody TokenReissueRequest request) {
         try {
             TokenReissueResponse response = authService.reissueAccessToken(request);
             return ResponseEntity.ok(new RsData<>(ResultCode.REISSUE_SUCCESS, "토큰 재발급 성공", response));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(new RsData<>(ResultCode.INVALID_REQUEST, e.getMessage()));
+        } catch (SecurityException e) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new RsData<>(ResultCode.TOKEN_EXPIRED, "유효하지 않은 RefreshToken입니다."));
         } catch (Exception e) {
             return ResponseEntity
                     .status(HttpStatus.UNAUTHORIZED)
-                    .body(new RsData<>(ResultCode.UNAUTHORIZED, "토큰 재발급 실패했습니다."));
+                    .body(new RsData<>(ResultCode.UNAUTHORIZED, "토큰 재발급에 실패했습니다."));
         }
     }
 }

--- a/src/main/java/com/back/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/back/domain/auth/controller/AuthController.java
@@ -2,7 +2,9 @@ package com.back.domain.auth.controller;
 
 import com.back.domain.auth.dto.request.MemberLoginRequest;
 import com.back.domain.auth.dto.request.MemberSignupRequest;
+import com.back.domain.auth.dto.request.TokenReissueRequest;
 import com.back.domain.auth.dto.response.MemberLoginResponse;
+import com.back.domain.auth.dto.response.TokenReissueResponse;
 import com.back.domain.auth.service.AuthService;
 import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.domain.member.entity.Member;
@@ -93,5 +95,19 @@ public class AuthController {
         authService.logout(member);
 
         return ResponseEntity.ok(new RsData<>(ResultCode.LOGOUT_SUCCESS, "로그아웃 성공", null));
+    }
+
+    // Access Token 재발급 API
+    @PostMapping("/reissue")
+    @Operation(summary = "AccessToken 재발급", description = "RefreshToken으로 AccessToken을 재발급 받습니다.")
+    public ResponseEntity<RsData<TokenReissueResponse>> reissue(@RequestBody TokenReissueRequest request) {
+        try {
+            TokenReissueResponse response = authService.reissueAccessToken(request);
+            return ResponseEntity.ok(new RsData<>(ResultCode.REISSUE_SUCCESS, "토큰 재발급 성공", response));
+        } catch (Exception e) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new RsData<>(ResultCode.UNAUTHORIZED, "토큰 재발급 실패했습니다."));
+        }
     }
 }

--- a/src/main/java/com/back/domain/auth/dto/request/TokenReissueRequest.java
+++ b/src/main/java/com/back/domain/auth/dto/request/TokenReissueRequest.java
@@ -1,4 +1,7 @@
 package com.back.domain.auth.dto.request;
 
-public record TokenReissueRequest(String refreshToken) {
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenReissueRequest(@NotBlank(message = "RefreshToken은 필수입니다.")
+                                  String refreshToken) {
 }

--- a/src/main/java/com/back/domain/auth/dto/request/TokenReissueRequest.java
+++ b/src/main/java/com/back/domain/auth/dto/request/TokenReissueRequest.java
@@ -1,0 +1,4 @@
+package com.back.domain.auth.dto.request;
+
+public record TokenReissueRequest(String refreshToken) {
+}

--- a/src/main/java/com/back/domain/auth/dto/response/TokenReissueResponse.java
+++ b/src/main/java/com/back/domain/auth/dto/response/TokenReissueResponse.java
@@ -1,0 +1,4 @@
+package com.back.domain.auth.dto.response;
+
+public record TokenReissueResponse(String accessToken, String refreshToken){
+}

--- a/src/main/java/com/back/domain/auth/dto/response/TokenReissueResponse.java
+++ b/src/main/java/com/back/domain/auth/dto/response/TokenReissueResponse.java
@@ -1,7 +1,4 @@
 package com.back.domain.auth.dto.response;
 
-import org.springframework.transaction.annotation.Transactional;
-
-@Transactional
 public record TokenReissueResponse(String accessToken, String refreshToken){
 }

--- a/src/main/java/com/back/domain/auth/dto/response/TokenReissueResponse.java
+++ b/src/main/java/com/back/domain/auth/dto/response/TokenReissueResponse.java
@@ -1,4 +1,7 @@
 package com.back.domain.auth.dto.response;
 
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
 public record TokenReissueResponse(String accessToken, String refreshToken){
 }

--- a/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -94,7 +94,12 @@ public class AuthService {
 
         // 6. 리프레시 토큰도 갱신
         member.updateRefreshToken(newRefreshToken);
-        memberRepository.save(member);
+        try {
+            memberRepository.save(member);
+        } catch (DataIntegrityViolationException e) {
+            log.error("리프레시 토큰 갱신 실패", e);
+            throw new ServiceException(ResultCode.SERVER_ERROR.code(), "토큰 갱신에 실패했습니다.");
+        }
 
         return new TokenReissueResponse(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -68,6 +68,7 @@ public class AuthService {
     }
 
     // Access Token 재발급
+    @Transactional
     public TokenReissueResponse reissueAccessToken(TokenReissueRequest request) {
         String refreshToken = request.refreshToken();
 

--- a/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -1,7 +1,9 @@
 package com.back.domain.auth.service;
 
 import com.back.domain.auth.dto.request.MemberLoginRequest;
+import com.back.domain.auth.dto.request.TokenReissueRequest;
 import com.back.domain.auth.dto.response.MemberLoginResponse;
+import com.back.domain.auth.dto.response.TokenReissueResponse;
 import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
@@ -63,5 +65,37 @@ public class AuthService {
     public void logout(Member member) {
         member.removeRefreshToken();
         memberRepository.save(member);
+    }
+
+    // Access Token 재발급
+    public TokenReissueResponse reissueAccessToken(TokenReissueRequest request) {
+        String refreshToken = request.refreshToken();
+
+        // 1. 토큰 유효성 확인
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new ServiceException(ResultCode.UNAUTHORIZED.code(), "유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        // 2. 이메일 추출
+        String email = jwtTokenProvider.getEmailFromToken(refreshToken);
+
+        // 3. 사용자 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ServiceException(ResultCode.MEMBER_NOT_FOUND.code(), "사용자를 찾을 수 없습니다."));
+
+        // 4. 저장된 리프레시 토큰과 일치하는지 확인
+        if (!refreshToken.equals(member.getRefreshToken())) {
+            throw new ServiceException(ResultCode.UNAUTHORIZED.code(), "토큰이 서버와 일치하지 않습니다.");
+        }
+
+        // 5. 새로운 토큰 생성
+        String newAccessToken = jwtTokenProvider.generateAccessToken(member);
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(member);
+
+        // 6. 리프레시 토큰도 갱신
+        member.updateRefreshToken(newRefreshToken);
+        memberRepository.save(member);
+
+        return new TokenReissueResponse(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/com/back/global/exception/ServiceException.java
+++ b/src/main/java/com/back/global/exception/ServiceException.java
@@ -13,6 +13,16 @@ public class ServiceException extends RuntimeException {
         this.msg = msg;
     }
 
+    // 예외 발생 시 클라이언트에게 전달할 ResultCode 반환
+    public String getResultCode() {
+        return resultCode;
+    }
+
+    // 예외 발생 시 클라이언트에게 전달할 Message 반환
+    public String getMsg() {
+        return msg;
+    }
+
     public RsData<Void> getRsData() {
         return new RsData<>(resultCode, msg, null);
     }

--- a/src/main/java/com/back/global/rsData/ResultCode.java
+++ b/src/main/java/com/back/global/rsData/ResultCode.java
@@ -7,6 +7,7 @@ public enum ResultCode {
     SIGNUP_SUCCESS("200-2", 200, "회원가입 성공"),
     GET_ME_SUCCESS("200-3", 200, "사용자 정보 조회 성공"),
     LOGOUT_SUCCESS("200-4", 200, "로그아웃 성공"),
+    REISSUE_SUCCESS("200-5", 200, "AccessToken 재발급 성공"),
 
     // 400: 클라이언트 오류
     INVALID_REQUEST("400-1", 400, "요청 오류"),
@@ -16,6 +17,7 @@ public enum ResultCode {
     UNAUTHORIZED("401-1", 401, "인증 정보 없음"),
     TOKEN_EXPIRED("401-2", 401, "토큰 만료"),
     INVALID_CREDENTIALS("401-3", 401, "이메일 또는 비밀번호 불일치"),
+    MEMBER_NOT_FOUND("401-4", 401, "존재하지 않는 회원"),
 
     // 403: 인가 오류
     FORBIDDEN("403-1", 403, "접근 권한 오류"),

--- a/src/main/java/com/back/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 경로들
-                        .requestMatchers("/api/auth/signup", "/api/auth/login").permitAll()
+                        .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/reissue").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
 
                         // Swagger 관련 경로들 - 더 구체적으로 설정

--- a/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
@@ -11,6 +11,9 @@ import com.back.global.rsData.ResultCode;
 import com.back.global.rsData.RsData;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +28,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Date;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -252,7 +256,94 @@ public class AuthControllerTest {
         // then: 401 Unauthorized 응답 및 메시지 검증
         resultActions
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.resultCode").value("401-1"))  // ResultCode.UNAUTHORIZED
-                .andExpect(jsonPath("$.msg").value("토큰 재발급 실패했습니다."));
+                .andExpect(jsonPath("$.resultCode").value("401-1"))
+                .andExpect(jsonPath("$.msg").value("토큰 재발급에 실패했습니다."));
+    }
+
+    @Test
+    @DisplayName("AccessToken 재발급 실패 - 토큰 불일치")
+    void reissueAccessToken_fail_tokenMismatch() throws Exception {
+        // 다른 사용자의 유효한 토큰으로 테스트
+        // given - 로그인
+        MemberLoginRequest loginRequest = new MemberLoginRequest("user1@user.com", "user1234!");
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // DB에 저장된 RefreshToken이 아닌 위조된 다른 문자열로 요청
+        TokenReissueRequest reissueRequest = new TokenReissueRequest("fake-but-valid-looking-refresh-token");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reissueRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("401-1"))
+                .andExpect(jsonPath("$.msg").value("토큰 재발급에 실패했습니다."));
+    }
+
+    @Test
+    @DisplayName("AccessToken 재발급 실패 - 존재하지 않는 사용자")
+    void reissueAccessToken_fail_memberNotFound() throws Exception {
+        // 유효한 토큰이지만 사용자가 삭제된 경우
+        // given - 토큰 수동 생성 (DB에 없는 사용자 이메일로)
+        String invalidEmail = "not@exist.com";
+        String fakeToken = Jwts.builder()
+                .setSubject(invalidEmail)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // 1시간
+                .signWith(Keys.hmacShaKeyFor("testsecretsecretsecretsecret1234".getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+
+        TokenReissueRequest reissueRequest = new TokenReissueRequest(fakeToken);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reissueRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("401-1"))
+                .andExpect(jsonPath("$.msg").value("토큰 재발급에 실패했습니다."));
+    }
+
+    @Test
+    @DisplayName("AccessToken 재발급 후 새로운 RefreshToken으로 재발급 가능")
+    void reissueAccessToken_canReissueWithNewToken() throws Exception {
+        // 재발급된 새로운 RefreshToken으로 다시 재발급 가능한지 확인
+        // 1차 로그인 → refreshToken 발급
+        MemberLoginRequest loginRequest = new MemberLoginRequest("user1@user.com", "user1234!");
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String firstRefreshToken = objectMapper.readTree(loginResult.getResponse().getContentAsString())
+                .get("data").get("refreshToken").asText();
+
+        // 1차 AccessToken 재발급
+        TokenReissueRequest firstReissue = new TokenReissueRequest(firstRefreshToken);
+        MvcResult reissueResult = mockMvc.perform(post("/api/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(firstReissue)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.refreshToken").exists())
+                .andReturn();
+
+        // 응답에서 새로운 refreshToken 획득
+        String newRefreshToken = objectMapper.readTree(reissueResult.getResponse().getContentAsString())
+                .get("data").get("refreshToken").asText();
+
+        // 2차 AccessToken 재발급 시도 (새 refreshToken으로)
+        TokenReissueRequest secondReissue = new TokenReissueRequest(newRefreshToken);
+        mockMvc.perform(post("/api/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(secondReissue)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-5"))
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andExpect(jsonPath("$.data.refreshToken").exists());
     }
 }


### PR DESCRIPTION
## 📢 기능 설명
 RefreshToken 유효기간 7일, AccessToken 유효기간 30분

1. RefreshToken 값을 비교하여 AccessToken을 재발급 받음
2. 추가로, RefreshToken 값도 새로 재발급 받아 보안을 더 강화시킴

AccessToken을 재발급 받는 이유는, 
1. 사용자가 로그인 후 활동이 없어 AccessToken이 만료된 경우
2. AccessToken이 곧 만료가 되어 미리 연장할 필요가 있을 때 (ex. 사용자에게 로그인 연장하겠냐는 메시지를 제공해줌)

지금 구조에서는 로그아웃시 RefreshToken -> null 저장이기 때문에, 사용자는 "재로그인" 이 필수임
지금 구조는 AccessToken을 만료시키려면 30분이 진짜 지나는 방법밖에 없음

Redis 블랙리스트 기법을 사용하거나
Front가 구현되면, Front에서 AccessToken을 삭제(무효화) 처리하는 방식으로 진행하면 됨

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #100 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 액세스 토큰 재발급을 위한 API 엔드포인트가 추가되었습니다. 리프레시 토큰을 사용해 새로운 액세스 토큰과 리프레시 토큰을 발급받을 수 있습니다.

* **버그 수정**
  * 존재하지 않는 회원에 대한 인증 오류 메시지가 개선되었습니다.

* **테스트**
  * 액세스 토큰 재발급 성공 및 다양한 실패 시나리오에 대한 테스트가 추가되었습니다.

* **기타**
  * 토큰 재발급 엔드포인트가 인증 없이 접근 가능한 경로에 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->