### PR TITLE
[feat] 채팅방 목록 조회(사용자별)

### DIFF
--- a/src/main/java/com/back/domain/chat/chat/controller/ChatRestController.java
+++ b/src/main/java/com/back/domain/chat/chat/controller/ChatRestController.java
@@ -1,5 +1,6 @@
 package com.back.domain.chat.chat.controller;
 
+import com.back.domain.chat.chat.dto.ChatRoomDto;
 import com.back.domain.chat.chat.dto.MessageDto;
 import com.back.domain.chat.chat.service.ChatService;
 import com.back.global.rsData.RsData;
@@ -22,10 +23,17 @@ public class ChatRestController {
         return new RsData<>("200-1", "채팅방 메시지 조회 성공", messageDtos);
     }
 
-    @PostMapping("/room/{postId}")
+    @PostMapping("/rooms/{postId}")
     public RsData<Void> createChatRoom(@PathVariable Long postId, Principal principal){
         chatService.createChatRoom(postId, principal.getName());
 
         return new RsData<>("200-1", "채팅방 생성 성공");
+    }
+
+    @GetMapping("/rooms/my")
+    public RsData<List<ChatRoomDto>> getMyChatRooms(Principal principal) {
+        List<ChatRoomDto> chatRooms = chatService.getMyChatRooms(principal);
+
+        return new RsData<>("200-1", "내 채팅방 목록 조회 성공", chatRooms);
     }
 }

--- a/src/main/java/com/back/domain/chat/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/back/domain/chat/chat/dto/ChatRoomDto.java
@@ -1,0 +1,19 @@
+package com.back.domain.chat.chat.dto;
+
+public record ChatRoomDto (
+    Long id,
+    String name,
+    Long postId,
+    String lastContent
+) {
+    public ChatRoomDto(Long id, String name, Long postId, String lastContent) {
+        this.id = id;
+        this.name = name;
+        this.postId = postId;
+        this.lastContent = lastContent;
+    }
+
+    public static ChatRoomDto from(Long id, String name, Long postId, String lastContent) {
+        return new ChatRoomDto(id, name, postId, lastContent);
+    }
+}

--- a/src/main/java/com/back/domain/chat/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/back/domain/chat/chat/dto/ChatRoomDto.java
@@ -6,13 +6,6 @@ public record ChatRoomDto (
     Long postId,
     String lastContent
 ) {
-    public ChatRoomDto(Long id, String name, Long postId, String lastContent) {
-        this.id = id;
-        this.name = name;
-        this.postId = postId;
-        this.lastContent = lastContent;
-    }
-
     public static ChatRoomDto from(Long id, String name, Long postId, String lastContent) {
         return new ChatRoomDto(id, name, postId, lastContent);
     }

--- a/src/main/java/com/back/domain/chat/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/back/domain/chat/chat/repository/ChatRoomRepository.java
@@ -13,4 +13,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     List<ChatRoom> findByPostId(Long postId); // 한개의 상품에 여러개의 채팅방이 있을 수 있음
 
     Optional<ChatRoom> findByPostIdAndUserName(Long postId, String userName);
+
+    // 사용자명으로 채팅방 목록 조회 (Principal용)
+    List<ChatRoom> findByNameOrderByCreatedAtDesc(String userName);
 }

--- a/src/main/java/com/back/domain/chat/chat/repository/MessageRepository.java
+++ b/src/main/java/com/back/domain/chat/chat/repository/MessageRepository.java
@@ -10,4 +10,7 @@ import java.util.List;
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
     List<Message> findByChatRoomId(Long chatRoomId);
+    
+    // 채팅방의 마지막 메시지 조회 (생성일시 기준 내림차순 첫번째)
+    Message findFirstByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
 }

--- a/src/test/java/com/back/domain/chat/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/back/domain/chat/chat/service/ChatServiceTest.java
@@ -1,6 +1,8 @@
 package com.back.domain.chat.chat.service;
 
+import com.back.domain.chat.chat.dto.ChatRoomDto;
 import com.back.domain.chat.chat.entity.ChatRoom;
+import com.back.domain.chat.chat.entity.Message;
 import com.back.domain.chat.chat.repository.ChatRoomRepository;
 import com.back.domain.chat.chat.repository.MessageRepository;
 import com.back.domain.member.repository.MemberRepository;
@@ -14,6 +16,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -165,5 +171,235 @@ class ChatServiceTest {
         // verify
         verify(postRepository, times(1)).findById(postId);
         verify(chatRoomRepository, times(1)).save(any(ChatRoom.class));
+    }
+
+    // =============== getMyChatRooms 테스트들 ===============
+
+    @Test
+    @DisplayName("내 채팅방 목록 조회 성공 - 메시지가 있는 경우")
+    void getMyChatRooms_Success_WithMessages() {
+        // given
+        Principal mockPrincipal = mock(Principal.class);
+        String userName = "testuser";
+        when(mockPrincipal.getName()).thenReturn(userName);
+
+        // Mock Post
+        Post mockPost1 = mock(Post.class);
+        Post mockPost2 = mock(Post.class);
+        when(mockPost1.getId()).thenReturn(1L);
+        when(mockPost2.getId()).thenReturn(2L);
+
+        // Mock ChatRoom
+        ChatRoom mockChatRoom1 = mock(ChatRoom.class);
+        ChatRoom mockChatRoom2 = mock(ChatRoom.class);
+        when(mockChatRoom1.getId()).thenReturn(1L);
+        when(mockChatRoom1.getName()).thenReturn(userName);
+        when(mockChatRoom1.getPost()).thenReturn(mockPost1);
+        when(mockChatRoom2.getId()).thenReturn(2L);
+        when(mockChatRoom2.getName()).thenReturn(userName);
+        when(mockChatRoom2.getPost()).thenReturn(mockPost2);
+
+        // Mock Message
+        Message mockMessage1 = mock(Message.class);
+        Message mockMessage2 = mock(Message.class);
+        when(mockMessage1.getContent()).thenReturn("안녕하세요!");
+        when(mockMessage2.getContent()).thenReturn("반갑습니다.");
+
+        // Mock Repository 응답
+        when(chatRoomRepository.findByNameOrderByCreatedAtDesc(userName))
+                .thenReturn(Arrays.asList(mockChatRoom1, mockChatRoom2));
+        when(messageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(1L)).thenReturn(mockMessage1);
+        when(messageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(2L)).thenReturn(mockMessage2);
+
+        // when
+        List<ChatRoomDto> result = chatService.getMyChatRooms(mockPrincipal);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        ChatRoomDto dto1 = result.get(0);
+        assertThat(dto1.id()).isEqualTo(1L);
+        assertThat(dto1.name()).isEqualTo(userName);
+        assertThat(dto1.postId()).isEqualTo(1L);
+        assertThat(dto1.lastContent()).isEqualTo("안녕하세요!");
+
+        ChatRoomDto dto2 = result.get(1);
+        assertThat(dto2.id()).isEqualTo(2L);
+        assertThat(dto2.name()).isEqualTo(userName);
+        assertThat(dto2.postId()).isEqualTo(2L);
+        assertThat(dto2.lastContent()).isEqualTo("반갑습니다.");
+
+        // verify
+        verify(chatRoomRepository, times(1)).findByNameOrderByCreatedAtDesc(userName);
+        verify(messageRepository, times(1)).findFirstByChatRoomIdOrderByCreatedAtDesc(1L);
+        verify(messageRepository, times(1)).findFirstByChatRoomIdOrderByCreatedAtDesc(2L);
+    }
+
+    @Test
+    @DisplayName("내 채팅방 목록 조회 성공 - 메시지가 없는 경우")
+    void getMyChatRooms_Success_WithoutMessages() {
+        // given
+        Principal mockPrincipal = mock(Principal.class);
+        String userName = "testuser";
+        when(mockPrincipal.getName()).thenReturn(userName);
+
+        // Mock Post
+        Post mockPost = mock(Post.class);
+        when(mockPost.getId()).thenReturn(1L);
+
+        // Mock ChatRoom
+        ChatRoom mockChatRoom = mock(ChatRoom.class);
+        when(mockChatRoom.getId()).thenReturn(1L);
+        when(mockChatRoom.getName()).thenReturn(userName);
+        when(mockChatRoom.getPost()).thenReturn(mockPost);
+
+        // Mock Repository 응답 - 메시지 없음
+        when(chatRoomRepository.findByNameOrderByCreatedAtDesc(userName))
+                .thenReturn(Arrays.asList(mockChatRoom));
+        when(messageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(1L)).thenReturn(null);
+
+        // when
+        List<ChatRoomDto> result = chatService.getMyChatRooms(mockPrincipal);
+
+        // then
+        assertThat(result).hasSize(1);
+
+        ChatRoomDto dto = result.get(0);
+        assertThat(dto.id()).isEqualTo(1L);
+        assertThat(dto.name()).isEqualTo(userName);
+        assertThat(dto.postId()).isEqualTo(1L);
+        assertThat(dto.lastContent()).isEqualTo("메시지가 없습니다.");
+
+        // verify
+        verify(chatRoomRepository, times(1)).findByNameOrderByCreatedAtDesc(userName);
+        verify(messageRepository, times(1)).findFirstByChatRoomIdOrderByCreatedAtDesc(1L);
+    }
+
+    @Test
+    @DisplayName("내 채팅방 목록 조회 성공 - 빈 목록")
+    void getMyChatRooms_Success_EmptyList() {
+        // given
+        Principal mockPrincipal = mock(Principal.class);
+        String userName = "testuser";
+        when(mockPrincipal.getName()).thenReturn(userName);
+
+        // Mock Repository 응답 - 빈 목록
+        when(chatRoomRepository.findByNameOrderByCreatedAtDesc(userName))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        List<ChatRoomDto> result = chatService.getMyChatRooms(mockPrincipal);
+
+        // then
+        assertThat(result).isEmpty();
+
+        // verify
+        verify(chatRoomRepository, times(1)).findByNameOrderByCreatedAtDesc(userName);
+        verify(messageRepository, never()).findFirstByChatRoomIdOrderByCreatedAtDesc(any());
+    }
+
+    @Test
+    @DisplayName("내 채팅방 목록 조회 실패 - null Principal")
+    void getMyChatRooms_Fail_NullPrincipal() {
+        // given
+        Principal nullPrincipal = null;
+
+        // when & then
+        assertThatThrownBy(() -> chatService.getMyChatRooms(nullPrincipal))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage("400-1 : 로그인 하셔야 합니다.");
+
+        // verify
+        verify(chatRoomRepository, never()).findByNameOrderByCreatedAtDesc(any());
+        verify(messageRepository, never()).findFirstByChatRoomIdOrderByCreatedAtDesc(any());
+    }
+
+    @Test
+    @DisplayName("내 채팅방 목록 조회 실패 - null userName")
+    void getMyChatRooms_Fail_NullUserName() {
+        // given
+        Principal mockPrincipal = mock(Principal.class);
+        when(mockPrincipal.getName()).thenReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> chatService.getMyChatRooms(mockPrincipal))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage("400-1 : 로그인 하셔야 합니다.");
+
+        // verify
+        verify(chatRoomRepository, never()).findByNameOrderByCreatedAtDesc(any());
+        verify(messageRepository, never()).findFirstByChatRoomIdOrderByCreatedAtDesc(any());
+    }
+
+    @Test
+    @DisplayName("내 채팅방 목록 조회 실패 - 빈 userName")
+    void getMyChatRooms_Fail_EmptyUserName() {
+        // given
+        Principal mockPrincipal = mock(Principal.class);
+        when(mockPrincipal.getName()).thenReturn("");
+
+        // when & then
+        assertThatThrownBy(() -> chatService.getMyChatRooms(mockPrincipal))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage("400-1 : 로그인 하셔야 합니다.");
+
+        // verify
+        verify(chatRoomRepository, never()).findByNameOrderByCreatedAtDesc(any());
+        verify(messageRepository, never()).findFirstByChatRoomIdOrderByCreatedAtDesc(any());
+    }
+
+    @Test
+    @DisplayName("내 채팅방 목록 조회 - 데이터 정렬 확인")
+    void getMyChatRooms_CheckDataOrder() {
+        // given
+        Principal mockPrincipal = mock(Principal.class);
+        String userName = "testuser";
+        when(mockPrincipal.getName()).thenReturn(userName);
+
+        // Mock Post
+        Post mockPost1 = mock(Post.class);
+        Post mockPost2 = mock(Post.class);
+        Post mockPost3 = mock(Post.class);
+        when(mockPost1.getId()).thenReturn(1L);
+        when(mockPost2.getId()).thenReturn(2L);
+        when(mockPost3.getId()).thenReturn(3L);
+
+        // Mock ChatRoom (생성일시 역순으로 정렬된 상태)
+        ChatRoom mockChatRoom1 = mock(ChatRoom.class); // 가장 최근
+        ChatRoom mockChatRoom2 = mock(ChatRoom.class);
+        ChatRoom mockChatRoom3 = mock(ChatRoom.class); // 가장 오래된
+
+        when(mockChatRoom1.getId()).thenReturn(3L);
+        when(mockChatRoom1.getName()).thenReturn(userName);
+        when(mockChatRoom1.getPost()).thenReturn(mockPost3);
+
+        when(mockChatRoom2.getId()).thenReturn(2L);
+        when(mockChatRoom2.getName()).thenReturn(userName);
+        when(mockChatRoom2.getPost()).thenReturn(mockPost2);
+
+        when(mockChatRoom3.getId()).thenReturn(1L);
+        when(mockChatRoom3.getName()).thenReturn(userName);
+        when(mockChatRoom3.getPost()).thenReturn(mockPost1);
+
+        // Mock Repository 응답
+        when(chatRoomRepository.findByNameOrderByCreatedAtDesc(userName))
+                .thenReturn(Arrays.asList(mockChatRoom1, mockChatRoom2, mockChatRoom3));
+        when(messageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(3L)).thenReturn(null);
+        when(messageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(2L)).thenReturn(null);
+        when(messageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(1L)).thenReturn(null);
+
+        // when
+        List<ChatRoomDto> result = chatService.getMyChatRooms(mockPrincipal);
+
+        // then
+        assertThat(result).hasSize(3);
+
+        // 최신 순서대로 정렬되었는지 확인
+        assertThat(result.get(0).id()).isEqualTo(3L);
+        assertThat(result.get(1).id()).isEqualTo(2L);
+        assertThat(result.get(2).id()).isEqualTo(1L);
+
+        // verify - OrderByCreatedAtDesc 메서드가 호출되었는지 확인
+        verify(chatRoomRepository, times(1)).findByNameOrderByCreatedAtDesc(userName);
     }
 }


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #105 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 본인과 관련된 채팅방 목록을 조회할 수 있는 새로운 엔드포인트가 추가되었습니다.
  * 채팅방 목록 조회 시, 각 채팅방의 최근 메시지 내용이 함께 표시됩니다.

* **버그 수정**
  * 채팅방 생성 엔드포인트의 경로가 `/room/{postId}`에서 `/rooms/{postId}`로 변경되었습니다.

* **테스트**
  * 채팅방 목록 조회 기능에 대한 다양한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->