### PR TITLE
[feat] 회원 탈퇴(상태변경) 기능 추가

### DIFF
--- a/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -1,0 +1,44 @@
+package com.back.domain.member.controller;
+
+import com.back.domain.member.service.MemberService;
+import com.back.global.rsData.ResultCode;
+import com.back.global.rsData.RsData;
+import com.back.global.security.auth.MemberDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    // 회원 탈퇴(상태변경) API
+    @DeleteMapping("/me")
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 상태를 DELETED로 변경합니다.")
+    public ResponseEntity<RsData<String>> deleteCurrentMember(@AuthenticationPrincipal MemberDetails memberDetails) {
+        try {
+            memberService.deleteAccount(memberDetails.getMember());
+            return ResponseEntity.ok(
+                    new RsData<>(ResultCode.MEMBER_DELETE_SUCCESS, "회원 탈퇴 성공했습니다.")
+            );
+        } catch (NoSuchElementException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(new RsData<>(ResultCode.MEMBER_NOT_FOUND, e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new RsData<>(ResultCode.SERVER_ERROR, "서버 오류가 발생했습니다."));
+        }
+    }
+}

--- a/src/main/java/com/back/domain/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/entity/Member.java
@@ -67,4 +67,18 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
+    // 회원 탈퇴 (상태 변경)
+    public void delete() {
+        // 1. 이미 탈퇴한 회원인지 확인
+        if (this.status == Status.DELETED) {
+            throw new IllegalStateException("이미 탈퇴한 회원입니다.");
+        }
+
+        // 2 회원 상태를 DELETED로 변경
+        this.status = Status.DELETED;
+
+        // 3. 탈퇴 시간을 현재 시간으로 설정
+        this.deletedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/service/MemberService.java
@@ -10,6 +10,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -35,5 +37,18 @@ public class MemberService {
                 .build();
 
         memberRepository.save(member);
+    }
+
+    // 회원 탈퇴 (상태 변경)
+    @Transactional
+    public void deleteAccount(Member member) {
+
+        // 1. 회원 정보가 존재하는지 확인
+        if (member == null) {
+            throw new NoSuchElementException("회원 정보가 존재하지 않습니다.");
+        }
+
+        // 2. 회원 탈퇴 처리
+        member.delete();
     }
 }

--- a/src/main/java/com/back/global/rsData/ResultCode.java
+++ b/src/main/java/com/back/global/rsData/ResultCode.java
@@ -8,6 +8,7 @@ public enum ResultCode {
     GET_ME_SUCCESS("200-3", 200, "사용자 정보 조회 성공"),
     LOGOUT_SUCCESS("200-4", 200, "로그아웃 성공"),
     REISSUE_SUCCESS("200-5", 200, "AccessToken 재발급 성공"),
+    MEMBER_DELETE_SUCCESS("200-6", 200, "회원 탈퇴 성공"),
 
     // 400: 클라이언트 오류
     INVALID_REQUEST("400-1", 400, "요청 오류"),

--- a/src/test/java/com/back/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,89 @@
+package com.back.domain.member.controller;
+
+import com.back.domain.auth.dto.request.MemberLoginRequest;
+import com.back.domain.member.entity.Member;
+import com.back.domain.member.entity.Status;
+import com.back.domain.member.repository.MemberRepository;
+import com.back.global.rsData.RsData;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("MemberController 통합 테스트")
+public class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // 테스트 데이터 삽입용 의존성 (예시)
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("회원 탈퇴 성공 - 로그인 후 DELETE /api/members/me 호출")
+    void delete_account_success() throws Exception {
+        // given - 테스트용 회원 저장
+        String email = "user1@user.com";
+        String password = "user1234!";
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .name("홍길동")
+                .build();
+        memberRepository.save(member);
+
+        // 로그인 요청
+        MemberLoginRequest request = new MemberLoginRequest(email, password);
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseJson = loginResult.getResponse().getContentAsString();
+        RsData<Map<String, Object>> rsData = objectMapper.readValue(responseJson,
+                new TypeReference<RsData<Map<String, Object>>>() {});
+        String accessToken = rsData.data().get("accessToken").toString();
+
+        // when - 탈퇴 요청
+        mockMvc.perform(delete("/api/members/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-6"))
+                .andExpect(jsonPath("$.message").value("회원 탈퇴 성공했습니다."));
+
+        // then - 실제 DB 상태 확인
+        Member deletedMember = memberRepository.findByEmail(email).orElseThrow();
+        assertEquals(Status.DELETED, deletedMember.getStatus());
+    }
+
+}


### PR DESCRIPTION
## 📢 기능 설명
1. 회원 탈퇴 API 구현
2. 사용중(ACTIVE) 에서 -> 탈퇴됨(DELETED) 으로 변경


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #114 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원이 자신의 계정을 삭제(탈퇴)할 수 있는 API가 추가되었습니다.

* **버그 수정**
  * 회원 탈퇴 시 이미 탈퇴된 계정에 대한 예외 처리가 추가되었습니다.

* **테스트**
  * 회원 탈퇴 API의 정상 동작을 검증하는 통합 테스트가 추가되었습니다.

* **문서화**
  * 회원 탈퇴 API에 대한 Swagger 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->