### PR TITLE
[feat] 관리자 -> 회원 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/back/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/back/domain/admin/controller/AdminController.java
@@ -1,0 +1,39 @@
+package com.back.domain.admin.controller;
+
+import com.back.domain.admin.service.AdminService;
+import com.back.domain.member.dto.response.MemberInfoResponse;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @Operation(summary = "전체 회원 목록 조회", description = "모든 회원 목록을 페이징하여 조회합니다 (탈퇴 포함)")
+    @GetMapping("/members")
+    public ResponseEntity<RsData<Page<MemberInfoResponse>>> getAllMembers(
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable) {
+
+        Page<MemberInfoResponse> members = adminService.getAllMembers(pageable);
+
+        RsData<Page<MemberInfoResponse>> response =
+                new RsData<>("200-1", "회원 목록 조회 성공", members);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/back/domain/admin/service/AdminService.java
+++ b/src/main/java/com/back/domain/admin/service/AdminService.java
@@ -1,0 +1,28 @@
+package com.back.domain.admin.service;
+
+import com.back.domain.member.dto.response.MemberInfoResponse;
+import com.back.domain.member.entity.Role;
+import com.back.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminService {
+
+    private final MemberRepository memberRepository;
+
+    // 전체 회원 목록 조회(관리자 제외)
+    public Page<MemberInfoResponse> getAllMembers(Pageable pageable) {
+        log.info("전체 회원 목록 조회 요청 (관리자 제외)");
+
+        // 페이징 적용 및 DTO 변환하여 반환
+        return memberRepository.findAllByRoleNot(Role.ADMIN, pageable)
+                .map(MemberInfoResponse::fromEntity);
+    }
+
+}

--- a/src/main/java/com/back/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/back/domain/member/repository/MemberRepository.java
@@ -1,6 +1,9 @@
 package com.back.domain.member.repository;
 
 import com.back.domain.member.entity.Member;
+import com.back.domain.member.entity.Role;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByName(String name);
     boolean existsByEmail(String email);
+    Page<Member> findAllByRoleNot(Role role, Pageable pageable);
 }

--- a/src/main/java/com/back/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,6 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,11 @@ spring:
   output:
     ansi:
       enabled: always # ANSI 컬러 출력 설정
+  data:
+    web:
+      pageable:
+        default-page-size: 10 # 기본 페이지 크기
+        max-page-size: 50 # 최대 페이지 크기
 
 logging:
   level:

--- a/src/test/java/com/back/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/back/domain/admin/controller/AdminControllerTest.java
@@ -1,0 +1,79 @@
+package com.back.domain.admin.controller;
+
+import com.back.domain.files.files.service.FileStorageService;
+import com.back.domain.member.entity.Member;
+import com.back.domain.member.entity.Role;
+import com.back.domain.member.repository.MemberRepository;
+import com.back.global.security.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@PreAuthorize("hasRole('ADMIN')")
+@Transactional
+@DisplayName("AdminController 통합 테스트")
+public class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private FileStorageService fileStorageService;
+
+    @Test
+    @DisplayName("전체 회원 목록 조회 성공")
+    void getAllMembers_success() throws Exception {
+        // given - 관리자 계정 생성
+        String email = "testAdmin@admin.com";
+        String password = "admin1234!";
+        Member admin = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .name("관리자")
+                .role(Role.ADMIN)
+                .build();
+        memberRepository.save(admin);
+
+        // 토큰 생성
+        String token = jwtTokenProvider.generateAccessToken(admin);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/members")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sort", "createdAt,DESC")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("회원 목록 조회 성공"))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.pageable.pageNumber").value(0))
+                .andExpect(jsonPath("$.data.pageable.pageSize").value(10));
+    }
+}

--- a/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
@@ -3,6 +3,7 @@ package com.back.domain.auth.controller;
 import com.back.domain.auth.dto.request.MemberLoginRequest;
 import com.back.domain.auth.dto.request.MemberSignupRequest;
 import com.back.domain.auth.dto.request.TokenReissueRequest;
+import com.back.domain.files.files.service.FileStorageService;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.entity.Role;
 import com.back.domain.member.entity.Status;
@@ -14,7 +15,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -50,26 +51,14 @@ public class AuthControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    // 테스트 데이터 삽입용 의존성 (예시)
     @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    @BeforeEach
-    void setup() {
-        // JWT 로그인 테스트용 계정 추가
-        Member member = Member.builder()
-                .email("user1@user.com")
-                .password(passwordEncoder.encode("user1234!")) // 암호화 필수
-                .name("Test User")
-                .role(Role.USER)
-                .status(Status.ACTIVE)
-                .build();
-
-        memberRepository.save(member);
-    }
+    @MockitoBean
+    private FileStorageService fileStorageService;
 
     @Test
     @DisplayName("회원가입 성공")

--- a/src/test/java/com/back/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/controller/MemberControllerTest.java
@@ -1,6 +1,7 @@
 package com.back.domain.member.controller;
 
 import com.back.domain.auth.dto.request.MemberLoginRequest;
+import com.back.domain.files.files.service.FileStorageService;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.entity.Status;
 import com.back.domain.member.repository.MemberRepository;
@@ -15,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,11 +48,14 @@ public class MemberControllerTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @MockitoBean
+    private FileStorageService fileStorageService;
+
     @Test
     @DisplayName("회원 탈퇴 성공 - 로그인 후 DELETE /api/members/me 호출")
     void delete_account_success() throws Exception {
         // given - 테스트용 회원 저장
-        String email = "user1@user.com";
+        String email = "testUser1@user.com";
         String password = "user1234!";
         Member member = Member.builder()
                 .email(email)


### PR DESCRIPTION
## 📢 기능 설명
1. 관리자만 호출 가능한 회원 목록 조회 기능 추가
2. FileSotrageService 타입의 빈 오류가 있어, TestCode에 아래 코드 추가
    @MockitoBean
    private FileStorageService fileStorageService;


필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #130 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자 권한으로 전체 회원 목록(탈퇴 회원 포함)을 조회할 수 있는 관리용 엔드포인트가 추가되었습니다. (페이징 및 정렬 지원)

* **설정**
  * 기본 페이지 크기(10)와 최대 페이지 크기(50)에 대한 페이징 설정이 추가되었습니다.

* **보안**
  * 메서드 단위의 권한 체크가 활성화되어, 세밀한 접근 제어가 가능합니다.

* **테스트**
  * 관리자 회원 목록 조회 기능에 대한 통합 테스트가 추가되었습니다.
  * 일부 테스트에서 파일 저장소 서비스가 목(mock)으로 추가되었습니다.
  * 테스트 데이터 및 설정이 일부 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->