### PR TITLE
[feat] 관리자용 회원 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/back/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/back/domain/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.back.domain.admin.controller;
 
+import com.back.domain.admin.dto.response.AdminMemberResponse;
 import com.back.domain.admin.service.AdminService;
 import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.global.rsData.RsData;
@@ -12,6 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,6 +25,7 @@ public class AdminController {
 
     private final AdminService adminService;
 
+    // 전체 회원 목록 조회 API(탈퇴 포함)
     @Operation(summary = "전체 회원 목록 조회", description = "모든 회원 목록을 페이징하여 조회합니다 (탈퇴 포함)")
     @GetMapping("/members")
     public ResponseEntity<RsData<Page<MemberInfoResponse>>> getAllMembers(
@@ -35,5 +38,13 @@ public class AdminController {
                 new RsData<>("200-1", "회원 목록 조회 성공", members);
 
         return ResponseEntity.ok(response);
+    }
+
+    // 회원 상세 조회 API
+    @Operation(summary = "회원 상세 조회", description = "회원 ID를 통해 회원 정보를 상세 조회합니다")
+    @GetMapping("/members/{memberId}")
+    public ResponseEntity<RsData<AdminMemberResponse>> getMemberDetail(@PathVariable Long memberId) {
+        AdminMemberResponse response = adminService.getMemberDetail(memberId);
+        return ResponseEntity.ok(new RsData<>("200-2", "회원 상세 조회 성공", response));
     }
 }

--- a/src/main/java/com/back/domain/admin/service/AdminService.java
+++ b/src/main/java/com/back/domain/admin/service/AdminService.java
@@ -1,8 +1,11 @@
 package com.back.domain.admin.service;
 
+import com.back.domain.admin.dto.response.AdminMemberResponse;
 import com.back.domain.member.dto.response.MemberInfoResponse;
+import com.back.domain.member.entity.Member;
 import com.back.domain.member.entity.Role;
 import com.back.domain.member.repository.MemberRepository;
+import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -23,6 +26,15 @@ public class AdminService {
         // 페이징 적용 및 DTO 변환하여 반환
         return memberRepository.findAllByRoleNot(Role.ADMIN, pageable)
                 .map(MemberInfoResponse::fromEntity);
+    }
+
+    // 회원 상세 조회
+    public AdminMemberResponse getMemberDetail(Long memberId) {
+        log.info("회원 상세 조회 요청 - memberId: {}", memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ServiceException("404-1", "해당 회원이 존재하지 않습니다."));
+
+        return AdminMemberResponse.fromEntity(member);
     }
 
 }


### PR DESCRIPTION
## 📢 기능 설명
1. 관리자용 회원 상세 조회 기능 구현

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #140 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 회원 ID로 회원 상세 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 회원 상세 정보 조회 시 존재하지 않는 회원에 대해 404 오류와 명확한 메시지가 반환됩니다.

* **테스트**
  * 회원 상세 조회 성공 및 실패(존재하지 않는 회원) 케이스에 대한 테스트가 추가되었습니다.
  * 테스트 코드가 공통 admin 계정 및 토큰을 재사용하도록 리팩터링되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->