### PR TITLE
[refactor] A가 게시글 주인 B가 채팅 신청, C가 A의 게시글에 채팅신청 - A,B : A,C 따로 방 생성

### DIFF
--- a/src/main/java/com/back/domain/chat/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/back/domain/chat/chat/repository/ChatRoomRepository.java
@@ -11,11 +11,10 @@ import java.util.Optional;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     ChatRoom findByRoomName(String roomName);
     List<ChatRoom> findByPostId(Long postId); // 한개의 상품에 여러개의 채팅방이 있을 수 있음
-
+    List<ChatRoom> findByPostIdOrderByCreatedAtAsc(Long postId);
 
     // 특정 게시글에서 특정 사용자가 만든 채팅방 조회
     Optional<ChatRoom> findByPostIdAndMemberId(Long postId, Long memberId);
-
 
     // 특정 사용자가 만든 채팅방 목록 조회 (Principal용)
     List<ChatRoom> findByMemberIdOrderByCreatedAtDesc(Long memberId);

--- a/src/main/java/com/back/domain/chat/chat/repository/RoomParticipantRepository.java
+++ b/src/main/java/com/back/domain/chat/chat/repository/RoomParticipantRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface RoomParticipantRepository extends JpaRepository<RoomParticipant, Long> {
     boolean existsByChatRoomIdAndMemberIdAndIsActiveTrue(Long chatRoomId, Long memberId);
     List<RoomParticipant> findByChatRoomIdAndIsActiveTrue(Long chatRoomId);
+    List<RoomParticipant> findByChatRoomPostIdAndMemberIdAndIsActiveTrue(Long postId, Long memberId);
 }


### PR DESCRIPTION
## 📢 기능 설명


## A가 게시글 주인 B가 채팅 신청, C가 A의 게시글에 채팅신청 - A,B : A,C 따로 방 생성

[![2025-07-29-9-29-38.png](https://i.postimg.cc/dV9gHvcJ/2025-07-29-9-29-38.png)](https://postimg.cc/FY7PzMK6)

<br>

하나의 게시글에 두개의 채팅방 id 생성 

나만 아는 에러 한개 해결 ~! 

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #145 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 게시글 작성자가 자신의 글에 대해 채팅방을 생성할 수 없도록 제한이 추가되었습니다.
  * 게시글과 회원 정보를 기반으로 활성화된 1:1 채팅방이 이미 존재하는지 확인하는 기능이 개선되었습니다.

* **버그 수정**
  * 기존에 중복 채팅방이 생성될 수 있던 문제를 방지하여, 동일한 조건의 1:1 채팅방이 중복 생성되지 않도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->