### PR TITLE
[feat] 회원 마이페이지 조회

### DIFF
--- a/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -51,7 +51,7 @@ public class MemberController {
         try {
             MemberMyPageResponse response = memberService.findMyPage(memberDetails.getMember());
             return ResponseEntity.ok(
-                    new RsData<>("200-1", "마이페이지 조회 성공", response)
+                    new RsData<>(ResultCode.GET_ME_SUCCESS, "마이페이지 조회 성공", response)
             );
         } catch (NoSuchElementException e) {
             return ResponseEntity

--- a/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.back.domain.member.controller;
 
+import com.back.domain.member.dto.response.MemberMyPageResponse;
 import com.back.domain.member.service.MemberService;
 import com.back.global.rsData.ResultCode;
 import com.back.global.rsData.RsData;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,6 +37,26 @@ public class MemberController {
             return ResponseEntity
                     .status(HttpStatus.NOT_FOUND)
                     .body(new RsData<>(ResultCode.MEMBER_NOT_FOUND, e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new RsData<>(ResultCode.SERVER_ERROR, "서버 오류가 발생했습니다."));
+        }
+    }
+
+    // 회원 정보 조회 API (마이페이지)
+    @GetMapping("/me")
+    @Operation(summary = "마이페이지 조회", description = "현재 로그인한 사용자의 상세 정보를 반환합니다.")
+    public ResponseEntity<RsData<MemberMyPageResponse>> getMyPageInfo(@AuthenticationPrincipal MemberDetails memberDetails) {
+        try {
+            MemberMyPageResponse response = memberService.findMyPage(memberDetails.getMember());
+            return ResponseEntity.ok(
+                    new RsData<>("200-1", "마이페이지 조회 성공", response)
+            );
+        } catch (NoSuchElementException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(new RsData<>(ResultCode.MEMBER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
         } catch (Exception e) {
             return ResponseEntity
                     .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/back/domain/member/dto/response/MemberMyPageResponse.java
+++ b/src/main/java/com/back/domain/member/dto/response/MemberMyPageResponse.java
@@ -1,0 +1,29 @@
+package com.back.domain.member.dto.response;
+
+import com.back.domain.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+public record MemberMyPageResponse(
+        Long id,
+        String email,
+        String name,
+        String role,
+        String profileUrl,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static MemberMyPageResponse fromEntity(Member member) {
+        return new MemberMyPageResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getName(),
+                member.getRole().name(),
+                member.getProfileUrl(),
+                member.getStatus().name(),
+                member.getCreatedAt(),
+                member.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.back.domain.member.service;
 
 
 import com.back.domain.auth.dto.request.MemberSignupRequest;
+import com.back.domain.member.dto.response.MemberMyPageResponse;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -48,5 +49,15 @@ public class MemberService {
 
         // 2. 회원 탈퇴 처리
         foundMember.delete();
+    }
+
+    // 회원 마이페이지 조회
+    public MemberMyPageResponse findMyPage(Member member) {
+        // 1. 반드시 영속 상태로 다시 가져오기
+        Member foundMember = memberRepository.findById(member.getId())
+                .orElseThrow(() -> new NoSuchElementException("회원 정보가 존재하지 않습니다."));
+
+        // 2. 마이페이지 정보 반환
+        return MemberMyPageResponse.fromEntity(foundMember);
     }
 }


### PR DESCRIPTION
## 📢 기능 설명
1. 회원 마이페이지 조회 기능 추가

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #147 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그인한 사용자의 마이페이지 정보를 조회할 수 있는 새로운 API 엔드포인트(`/api/members/me`)가 추가되었습니다.

* **버그 수정**
  * 탈퇴한 회원이 마이페이지에 접근할 경우 적절한 오류 응답이 반환됩니다.

* **테스트**
  * 마이페이지 조회 성공 및 탈퇴 회원의 접근 실패에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->