### PR TITLE
[refactor] TestInitData 관리자 계정 추가

### DIFF
--- a/src/main/java/com/back/global/init/TestInitData.java
+++ b/src/main/java/com/back/global/init/TestInitData.java
@@ -2,6 +2,7 @@ package com.back.global.init;
 
 import com.back.domain.auth.dto.request.MemberSignupRequest;
 import com.back.domain.member.entity.Member;
+import com.back.domain.member.entity.Role;
 import com.back.domain.member.repository.MemberRepository;
 import com.back.domain.member.service.MemberService;
 import com.back.domain.post.entity.Post;
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -29,6 +31,7 @@ public class TestInitData {
     private final PostRepository postRepository;
     private final MemberService memberService;
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Bean
     ApplicationRunner testInitDataApplicationRunner() {
@@ -38,10 +41,21 @@ public class TestInitData {
         };
     }
 
-    // 유저 데이터 삽입
+    // 유저&관리자 데이터 삽입
     @Transactional
     public void work1() {
-        safeSignup("admin@admin.com", "admin1234!", "관리자");
+        // 관리자 계정 직접 생성
+        if (memberRepository.findByEmail("admin@admin.com").isEmpty()) {
+            Member admin = Member.builder()
+                    .email("admin@admin.com")
+                    .password(passwordEncoder.encode("admin1234!"))
+                    .name("관리자")
+                    .role(Role.ADMIN)
+                    .build();
+            memberRepository.save(admin);
+        }
+
+        // 일반 유저 계정 생성
         safeSignup("user1@user.com", "user1234!", "유저1");
         safeSignup("user2@user.com", "user1234!", "유저2");
         safeSignup("user3@user.com", "user1234!", "유저3");

--- a/src/test/java/com/back/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/back/domain/admin/controller/AdminControllerTest.java
@@ -2,10 +2,7 @@ package com.back.domain.admin.controller;
 
 import com.back.domain.files.files.service.FileStorageService;
 import com.back.domain.member.entity.Member;
-import com.back.domain.member.entity.Role;
 import com.back.domain.member.repository.MemberRepository;
-import com.back.global.security.jwt.JwtTokenProvider;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,9 +31,6 @@ public class AdminControllerTest {
     private MockMvc mockMvc;
 
     @Autowired
-    private JwtTokenProvider jwtTokenProvider;
-
-    @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
@@ -44,31 +39,15 @@ public class AdminControllerTest {
     @MockitoBean
     private FileStorageService fileStorageService;
 
-    private String adminToken;
-    private Member admin;
-
-    // 테스트용 관리자 계정 생성
-    @BeforeEach
-    void setUpAdminAccount() {
-        admin = Member.builder()
-                .email("testAdmin@admin.com")
-                .password(passwordEncoder.encode("admin1234!"))
-                .name("테스트관리자")
-                .role(Role.ADMIN)  // 반드시 ADMIN
-                .build();
-        memberRepository.save(admin);
-
-        adminToken = jwtTokenProvider.generateAccessToken(admin);
-    }
 
     @Test
     @DisplayName("전체 회원 목록 조회 성공")
-    void getAllMembers_success() throws Exception {// when & then
+    @WithUserDetails(value = "admin@admin.com", userDetailsServiceBeanName = "customUserDetailsService")
+    void getAllMembers_success() throws Exception {
         mockMvc.perform(get("/api/admin/members")
                         .param("page", "0")
                         .param("size", "10")
                         .param("sort", "createdAt,DESC")
-                        .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
@@ -80,43 +59,30 @@ public class AdminControllerTest {
 
     @Test
     @DisplayName("전체 회원 목록 조회 실패 - 관리자 권한 없음")
+    @WithUserDetails(value = "user2@user.com", userDetailsServiceBeanName = "customUserDetailsService")
     void getAllMembers_unauthorized() throws Exception {
-        // given - user2는 TestInitData에서 생성됨
-        Member member = memberRepository.findByEmail("user2@user.com").orElseThrow();
-
-        String token = jwtTokenProvider.generateAccessToken(member);
-
-        // when & then
         mockMvc.perform(get("/api/admin/members")
-                        .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     @DisplayName("회원 상세 조회 성공")
+    @WithUserDetails(value = "admin@admin.com", userDetailsServiceBeanName = "customUserDetailsService")
     void getMemberDetail() throws Exception {
-        // given - user2는 TestInitData에서 생성됨
-         Member member = memberRepository.findByEmail("user2@user.com").orElseThrow();
+        Member member = memberRepository.findByEmail("user2@user.com").orElseThrow();
 
-        // when & then
         mockMvc.perform(get("/api/admin/members/{memberId}", member.getId())
-                        .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.email").value("user2@user.com"));
     }
 
-
     @Test
     @DisplayName("회원 상세 조회 실패 - 존재하지 않는 회원")
+    @WithUserDetails(value = "admin@admin.com", userDetailsServiceBeanName = "customUserDetailsService")
     void getMemberDetail_notFound() throws Exception {
-        // given - 존재하지 않는 회원 ID
-        Long nonExistentMemberId = 999L;
-
-        // when & then
-        mockMvc.perform(get("/api/admin/members/{memberId}", nonExistentMemberId)
-                        .header("Authorization", "Bearer " + adminToken)
+        mockMvc.perform(get("/api/admin/members/{memberId}", 999L)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.resultCode").value("404-1"))


### PR DESCRIPTION
## 📢 기능 설명
1. 관리자 계정은 signUp 메소드를 통해 생성이 불가능하여, Member 엔티티의 Builder를 통해 직접 생성함
2. 테스트 코드에서 @WithUserDetails(value = "admin@admin.com") 어노테이션 사용하면, admin 계정 사용 가능

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #156 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 테스트 데이터 초기화 시 관리자 계정이 명확하게 생성되도록 개선되었습니다.
* **리팩터링**
  * 관리자 컨트롤러 테스트에서 인증 처리가 간소화되어, JWT 토큰 생성 대신 어노테이션 기반 인증 방식을 사용하도록 변경되었습니다.  
  * 불필요한 코드와 주석이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->