### PR TITLE
[feat] 관리자 -> 회원 정보 수정

### DIFF
--- a/src/main/java/com/back/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/back/domain/admin/controller/AdminController.java
@@ -1,10 +1,13 @@
 package com.back.domain.admin.controller;
 
+import com.back.domain.admin.dto.request.AdminUpdateMemberRequest;
 import com.back.domain.admin.dto.response.AdminMemberResponse;
 import com.back.domain.admin.service.AdminService;
 import com.back.domain.member.dto.response.MemberInfoResponse;
+import com.back.global.rsData.ResultCode;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,10 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/admin")
@@ -46,5 +46,18 @@ public class AdminController {
     public ResponseEntity<RsData<AdminMemberResponse>> getMemberDetail(@PathVariable Long memberId) {
         AdminMemberResponse response = adminService.getMemberDetail(memberId);
         return ResponseEntity.ok(new RsData<>("200-2", "회원 상세 조회 성공", response));
+    }
+
+    // 회원 정보 수정 API
+    @PatchMapping("/members/{memberId}")
+    @Operation(summary = "회원 정보 수정 (관리자)", description = "관리자가 회원 정보를 수정합니다.")
+    public ResponseEntity<RsData<String>> updateMemberByAdmin(
+            @PathVariable Long memberId,
+            @RequestBody @Valid AdminUpdateMemberRequest request
+    ) {
+        adminService.updateMemberInfo(memberId, request);
+        return ResponseEntity.ok(
+                new RsData<>(ResultCode.MEMBER_UPDATE_SUCCESS, "회원 정보 수정 성공")
+        );
     }
 }

--- a/src/main/java/com/back/domain/admin/dto/request/AdminUpdateMemberRequest.java
+++ b/src/main/java/com/back/domain/admin/dto/request/AdminUpdateMemberRequest.java
@@ -1,0 +1,10 @@
+package com.back.domain.admin.dto.request;
+
+import com.back.domain.member.entity.Status;
+
+public record AdminUpdateMemberRequest(
+        String name,
+        Status status,
+        String profileUrl,
+        boolean resetPassword
+) {}

--- a/src/main/java/com/back/domain/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/entity/Member.java
@@ -82,7 +82,7 @@ public class Member extends BaseEntity {
     }
 
 
-    // 회원 정보 수정
+    // 회원 정보 수정 - 시작
     public void updateName(String newName) {
         this.name = newName;
     }
@@ -94,5 +94,10 @@ public class Member extends BaseEntity {
     public void updateProfileUrl(String newProfileUrl) {
         this.profileUrl = newProfileUrl;
     }
+
+    public void changeStatus(Status newStatus) {
+        this.status = newStatus;
+    }
+    // 회원 정보 수정 - 끝
 
 }

--- a/src/test/java/com/back/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/back/domain/admin/controller/AdminControllerTest.java
@@ -1,8 +1,11 @@
 package com.back.domain.admin.controller;
 
+import com.back.domain.admin.dto.request.AdminUpdateMemberRequest;
 import com.back.domain.files.files.service.FileStorageService;
 import com.back.domain.member.entity.Member;
+import com.back.domain.member.entity.Status;
 import com.back.domain.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +19,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -32,6 +38,9 @@ public class AdminControllerTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -87,6 +96,58 @@ public class AdminControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.resultCode").value("404-1"))
                 .andExpect(jsonPath("$.msg").value("해당 회원이 존재하지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정 성공")
+    @WithUserDetails(value = "admin@admin.com")
+    void updateMember_success() throws Exception {
+        // given
+        Member member = memberRepository.findByEmail("user2@user.com").orElseThrow();
+
+        AdminUpdateMemberRequest request = new AdminUpdateMemberRequest(
+                "변경된이름",
+                Status.BLOCKED,
+                "https://new.image.url/profile.png",
+                true // 비밀번호 초기화 요청
+        );
+
+        // when
+        mockMvc.perform(patch("/api/admin/members/" + member.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-7"))
+                .andExpect(jsonPath("$.msg").value("회원 정보 수정 성공"));
+
+        // then
+        Member updated = memberRepository.findById(member.getId()).orElseThrow();
+        assertEquals("변경된이름", updated.getName());
+        assertEquals(Status.BLOCKED, updated.getStatus());
+        assertEquals("https://new.image.url/profile.png", updated.getProfileUrl());
+        assertTrue(passwordEncoder.matches("test1234!", updated.getPassword()));
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정 실패 - 존재하지 않는 회원")
+    @WithUserDetails(value = "admin@admin.com")
+    void updateMember_fail_notFound() throws Exception {
+        // given
+        Long invalidId = 9999L;
+        AdminUpdateMemberRequest request = new AdminUpdateMemberRequest(
+                "아무거나",
+                Status.ACTIVE,
+                null,
+                false
+        );
+
+        // when & then
+        mockMvc.perform(patch("/api/admin/members/" + invalidId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404-1"))
+                .andExpect(jsonPath("$.msg").value("해당 데이터가 존재하지 않습니다."));
     }
 
 }


### PR DESCRIPTION
## 📢 기능 설명
1. 관리자가 회원의 정보를 수정하는 기능 추가

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #158 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 회원 정보를 수정할 수 있는 API 엔드포인트가 추가되었습니다. (이름, 상태, 프로필 URL, 비밀번호 초기화 지원)
* **버그 수정**
  * 존재하지 않는 회원 ID로 수정 시 적절한 오류 응답이 반환됩니다.
* **테스트**
  * 회원 정보 수정 성공 및 실패(존재하지 않는 회원) 시나리오에 대한 통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->