### PR TITLE
[feat] 타 회원 정보 조회

### DIFF
--- a/src/main/java/com/back/domain/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.back.domain.member.controller;
 
 import com.back.domain.member.dto.request.MemberUpdateRequest;
 import com.back.domain.member.dto.response.MemberMyPageResponse;
+import com.back.domain.member.dto.response.OtherMemberInfoResponse;
 import com.back.domain.member.service.MemberService;
 import com.back.global.rsData.ResultCode;
 import com.back.global.rsData.RsData;
@@ -82,6 +83,22 @@ public class MemberController {
             return ResponseEntity
                     .status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new RsData<>(ResultCode.SERVER_ERROR, "서버 오류가 발생했습니다."));
+        }
+    }
+
+    // 사용자 프로필 조회 API
+    @GetMapping("/{id}")
+    @Operation(summary = "사용자 프로필 조회", description = "간단한 사용자 프로필 정보를 제공합니다.")
+    public ResponseEntity<RsData<OtherMemberInfoResponse>> getOtherMemberProfile(@PathVariable Long id) {
+        try {
+            OtherMemberInfoResponse response = memberService.getMemberProfileById(id);
+            return ResponseEntity.ok(
+                    new RsData<>(ResultCode.GET_OTHER_SUCCESS, "프로필 조회 성공", response)
+            );
+        } catch (NoSuchElementException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(new RsData<>(ResultCode.MEMBER_NOT_FOUND, e.getMessage()));
         }
     }
 

--- a/src/main/java/com/back/domain/member/dto/response/OtherMemberInfoResponse.java
+++ b/src/main/java/com/back/domain/member/dto/response/OtherMemberInfoResponse.java
@@ -1,0 +1,15 @@
+package com.back.domain.member.dto.response;
+
+import com.back.domain.member.entity.Member;
+
+public record OtherMemberInfoResponse(
+        String name,
+        String profileUrl
+) {
+    public static OtherMemberInfoResponse fromEntity(Member member) {
+        return new OtherMemberInfoResponse(
+                member.getName(),
+                member.getProfileUrl()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ package com.back.domain.member.service;
 import com.back.domain.auth.dto.request.MemberSignupRequest;
 import com.back.domain.member.dto.request.MemberUpdateRequest;
 import com.back.domain.member.dto.response.MemberMyPageResponse;
+import com.back.domain.member.dto.response.OtherMemberInfoResponse;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -91,6 +92,13 @@ public class MemberService {
 
             foundMember.updatePassword(passwordEncoder.encode(request.newPassword()));
         }
+    }
+
+    // 사용자 프로필 조회
+    public OtherMemberInfoResponse getMemberProfileById(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("해당 사용자가 존재하지 않습니다."));
+        return OtherMemberInfoResponse.fromEntity(member);
     }
 
 }

--- a/src/main/java/com/back/global/rsData/ResultCode.java
+++ b/src/main/java/com/back/global/rsData/ResultCode.java
@@ -10,6 +10,7 @@ public enum ResultCode {
     REISSUE_SUCCESS("200-5", 200, "AccessToken 재발급 성공"),
     MEMBER_DELETE_SUCCESS("200-6", 200, "회원 탈퇴 성공"),
     MEMBER_UPDATE_SUCCESS("200-7", 200, "회원 정보 수정 성공"),
+    GET_OTHER_SUCCESS("200-8", 200, "사용자 프로필 정보 조회 성공"),
 
     // ----------------------- [400: 잘못된 요청] -----------------------
     INVALID_REQUEST("400-1", 400, "잘못된 요청입니다."),

--- a/src/test/java/com/back/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/controller/MemberControllerTest.java
@@ -208,4 +208,40 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("$.resultCode").value("400-4"))
                 .andExpect(jsonPath("$.msg").value("현재 비밀번호를 입력해주세요."));
     }
+
+    @Test
+    @DisplayName("타 회원 프로필 조회 성공")
+    @WithUserDetails(value = "user1@user.com")
+    void getOtherMemberProfile_success() throws Exception {
+        // given
+        Member otherMember = memberRepository.save(Member.builder()
+                .email("other@user.com")
+                .password(passwordEncoder.encode("user1234!"))
+                .name("다른유저")
+                .profileUrl("https://example.com/profile.jpg")
+                .status(Status.ACTIVE)
+                .build());
+
+        // when & then
+        mockMvc.perform(get("/api/members/" + otherMember.getId() + "/profile"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-8")) // 실제 ResultCode 값에 맞게 수정
+                .andExpect(jsonPath("$.msg").value("프로필 조회 성공"))
+                .andExpect(jsonPath("$.data.name").value("다른유저"))
+                .andExpect(jsonPath("$.data.profileUrl").value("https://example.com/profile.jpg"));
+    }
+
+    @Test
+    @DisplayName("타 회원 프로필 조회 실패 - 존재하지 않는 ID")
+    @WithUserDetails(value = "user1@user.com")
+    void getOtherMemberProfile_fail_notFound() throws Exception {
+        // given
+        Long nonExistentId = 99999L;
+
+        // when & then
+        mockMvc.perform(get("/api/members/" + nonExistentId + "/profile"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404-2"))
+                .andExpect(jsonPath("$.msg").value("해당 사용자가 존재하지 않습니다."));
+    }
 }

--- a/src/test/java/com/back/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/controller/MemberControllerTest.java
@@ -223,9 +223,9 @@ public class MemberControllerTest {
                 .build());
 
         // when & then
-        mockMvc.perform(get("/api/members/" + otherMember.getId() + "/profile"))
+        mockMvc.perform(get("/api/members/" + otherMember.getId()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value("200-8")) // 실제 ResultCode 값에 맞게 수정
+                .andExpect(jsonPath("$.resultCode").value("200-8"))
                 .andExpect(jsonPath("$.msg").value("프로필 조회 성공"))
                 .andExpect(jsonPath("$.data.name").value("다른유저"))
                 .andExpect(jsonPath("$.data.profileUrl").value("https://example.com/profile.jpg"));
@@ -239,7 +239,7 @@ public class MemberControllerTest {
         Long nonExistentId = 99999L;
 
         // when & then
-        mockMvc.perform(get("/api/members/" + nonExistentId + "/profile"))
+        mockMvc.perform(get("/api/members/" + nonExistentId))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.resultCode").value("404-2"))
                 .andExpect(jsonPath("$.msg").value("해당 사용자가 존재하지 않습니다."));


### PR DESCRIPTION
## 📢 기능 설명
1. 일반 사용자가 다른 사용자의 프로필을 조회하는 기능 추가
이름, 프로필 이미지 두 개만 조회

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #164 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 ID로 간단한 프로필 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 존재하지 않는 사용자 ID로 조회 시 404 오류와 함께 적절한 메시지가 반환됩니다.

* **테스트**
  * 사용자 프로필 조회 성공 및 실패(존재하지 않는 사용자) 시나리오에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->