### PR TITLE
[chore] CORS 보안 기능 설정 추가

### DIFF
--- a/src/main/java/com/back/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/config/SecurityConfig.java
@@ -18,6 +18,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -31,6 +37,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
+                // CORS 설정
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 경로들
@@ -67,6 +75,35 @@ public class SecurityConfig {
 
 
         return http.build();
+    }
+
+    // CORS 설정
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        
+        // 허용할 오리진 설정 (개발 환경)
+        configuration.setAllowedOriginPatterns(List.of("http://localhost:3000"));
+        
+        // 허용할 HTTP 메서드 설정
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        
+        // 허용할 헤더 설정
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        
+        // 인증 정보 포함 허용
+        configuration.setAllowCredentials(true);
+        
+        // 노출할 헤더 설정
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Content-Type"));
+        
+        // 프리플라이트 요청 캐시 시간 설정 (1시간)
+        configuration.setMaxAge(3600L);
+        
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        
+        return source;
     }
 
     @Bean


### PR DESCRIPTION
## 📢 기능 설명
CORS 설정
브라우저가 다른 도메인 에서 리소스를 요청할 때, 이를 명시적으로 허용했는지 검사하는 보안 기능

예시 상황:
-프론트엔드 주소: http://localhost:3000/
-백엔드 주소: http://localhost:8080/

=> 이 경우, 다른 도메인이기 때문에 CORS 정책에 걸리기 때문, 브라우저가 요청을 차단하지 않도록 백엔드에서 "프론트엔드 주소를 허용" 하도록 설정해야함
=> 추후, 배포까지 연동 될 경우, 내용수정할 필요가 있어보임

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #173 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * CORS(교차 출처 리소스 공유) 설정이 추가되어, 프론트엔드(예: http://localhost:3000)에서 백엔드로의 요청이 허용됩니다.
  * 지정된 HTTP 메서드 및 헤더에 대한 접근이 가능하며, 인증 정보와 특정 헤더 노출이 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->