### PR TITLE
[fix] 채팅메시지 전송시 발송자 이름 누락 문제해결

### DIFF
--- a/src/main/java/com/back/domain/chat/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/back/domain/chat/chat/controller/ChatWebSocketController.java
@@ -22,7 +22,7 @@ public class ChatWebSocketController {
     @MessageMapping("/sendMessage")
     public void sendMessage(MessageDto chatMessage) {
         log.info("=== WebSocket 메시지 수신 ===");
-        log.info("sender: {}", chatMessage.getSender());
+        log.info("sender: {}", chatMessage.getSenderName());
         log.info("senderEmail: {}", chatMessage.getSenderEmail());
         log.info("content: {}", chatMessage.getContent());
         log.info("senderId: {}", chatMessage.getSenderId());

--- a/src/main/java/com/back/domain/chat/chat/dto/MessageDto.java
+++ b/src/main/java/com/back/domain/chat/chat/dto/MessageDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.Setter;
 
 import java.util.Objects;
@@ -15,13 +16,16 @@ public class MessageDto {
     private Long senderId;
     private Long chatRoomId;
 
+    @JsonProperty("senderName")
     private String senderName;
+    @NonNull
     private String senderEmail;
+    @NonNull
     private String content;
 
     // Jackson JSON 역직렬화를 위한 sender 필드 (senderName과 동일)
-    @JsonProperty("sender")
-    private String sender;
+
+//    private String sender;
 
     @JsonCreator
     public MessageDto(
@@ -47,7 +51,7 @@ public class MessageDto {
 
 
     public void setSender(String sender) {
-        this.sender = sender;
+//        this.sender = sender;
         this.senderName = sender;
     }
 

--- a/src/main/java/com/back/domain/chat/redis/listener/RedisMessageSubscriber.java
+++ b/src/main/java/com/back/domain/chat/redis/listener/RedisMessageSubscriber.java
@@ -41,7 +41,7 @@ public class RedisMessageSubscriber implements MessageListener {
 
             log.info("변환된 메시지 - 채팅방: {}, 발신자: {}, 내용: {}",
                     chatMessage.getChatRoomId(),
-                    chatMessage.getSender(),
+                    chatMessage.getSenderName(),
                     chatMessage.getContent());
 
             // WebSocket을 통해 클라이언트들에게 전송

--- a/src/main/java/com/back/domain/chat/redis/publisher/RedisMessagePublisher.java
+++ b/src/main/java/com/back/domain/chat/redis/publisher/RedisMessagePublisher.java
@@ -24,7 +24,7 @@ public class RedisMessagePublisher {
             log.info("=== Redis Publisher 메시지 발행 ===");
             log.info("발행할 메시지: 채팅방={}, 발신자={}, 내용={}",
                     message.getChatRoomId(),
-                    message.getSender(),
+                    message.getSenderName(),
                     message.getContent());
 
             // Redis 채널에 메시지 발행

--- a/src/main/java/com/back/domain/chat/redis/service/RedisMessageService.java
+++ b/src/main/java/com/back/domain/chat/redis/service/RedisMessageService.java
@@ -26,7 +26,7 @@ public class RedisMessageService {
             log.info("=== Redis로 메시지 발행 ===");
             log.info("채팅방: {}, 발신자: {}, 내용: {}",
                     message.getChatRoomId(),
-                    message.getSender(),
+                    message.getSenderName(),
                     message.getContent());
 
             // MessageDto를 JSON 문자열로 변환


### PR DESCRIPTION
## 📢 기능 설명
[fix] 채팅메시지 전송시 발송자 이름 누락 문제해결

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #178 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 채팅 메시지 관련 로그에 발신자 이름이 올바르게 표시되도록 개선되었습니다.
  * 메시지 데이터에서 발신자 이메일과 내용이 반드시 입력되도록 처리되었습니다.
  * 메시지 데이터의 발신자 이름 필드가 명확하게 JSON에 매핑되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->