### PR TITLE
[fix] 채팅방 목록 조회 생성자 기준 말고 참여자 기준으로 변경

### DIFF
--- a/src/main/java/com/back/domain/chat/chat/controller/ChatRestController.java
+++ b/src/main/java/com/back/domain/chat/chat/controller/ChatRestController.java
@@ -4,6 +4,7 @@ import com.back.domain.chat.chat.dto.ChatRoomDto;
 import com.back.domain.chat.chat.dto.MessageDto;
 import com.back.domain.chat.chat.service.ChatService;
 import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +17,7 @@ import java.util.List;
 public class ChatRestController {
     private final ChatService chatService;
 
-
+    @Operation(summary = "채팅 메시지 조회")
     @GetMapping("/rooms/{chatRoomId}/messages")
     public RsData<List<MessageDto>> getChatRoomMessages(@PathVariable Long chatRoomId, Principal principal) {
         List<MessageDto> messageDtos = chatService.getChatRoomMessages(chatRoomId, principal);
@@ -24,6 +25,7 @@ public class ChatRestController {
         return new RsData<>("200-1", "채팅방 메시지 조회 성공", messageDtos);
     }
 
+    @Operation(summary = "채팅방 생성")
     @PostMapping("/rooms/{postId}")
     public RsData<Long> createChatRoom(@PathVariable Long postId, Principal principal){
         Long chatRoomId = chatService.createChatRoom(postId, principal.getName());
@@ -31,6 +33,7 @@ public class ChatRestController {
         return new RsData<>("200-1", "채팅방 생성 성공", chatRoomId);
     }
 
+    @Operation(summary = "내가 속한 채팅방 목록 조회")
     @GetMapping("/rooms/my")
     public RsData<List<ChatRoomDto>> getMyChatRooms(Principal principal) {
         List<ChatRoomDto> chatRooms = chatService.getMyChatRooms(principal);
@@ -38,6 +41,7 @@ public class ChatRestController {
         return new RsData<>("200-1", "내 채팅방 목록 조회 성공", chatRooms);
     }
 
+    @Operation(summary = "채팅방 삭제")
     @DeleteMapping("/rooms/{chatRoomId}")
     public RsData<ChatRoomDto> deleteChatRoom(@PathVariable Long chatRoomId) {
         chatService.deleteChatRoom(chatRoomId);

--- a/src/main/java/com/back/domain/chat/chat/repository/RoomParticipantRepository.java
+++ b/src/main/java/com/back/domain/chat/chat/repository/RoomParticipantRepository.java
@@ -11,4 +11,6 @@ public interface RoomParticipantRepository extends JpaRepository<RoomParticipant
     boolean existsByChatRoomIdAndMemberIdAndIsActiveTrue(Long chatRoomId, Long memberId);
     List<RoomParticipant> findByChatRoomIdAndIsActiveTrue(Long chatRoomId);
     List<RoomParticipant> findByChatRoomPostIdAndMemberIdAndIsActiveTrue(Long postId, Long memberId);
+
+    List<RoomParticipant> findByMemberIdAndIsActiveTrueOrderByCreatedAtDesc(Long id);
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -441,9 +441,9 @@
             var existingMessages = Array.from(messages.children).slice(-5);
             var isDuplicate = existingMessages.some(msg => {
                 return msg.textContent &&
-                       msg.textContent.includes(message.content) &&
-                       msg.classList.contains('my-message') &&
-                       !msg.textContent.includes('(기록)'); // 기록 메시지는 제외
+                    msg.textContent.includes(message.content) &&
+                    msg.classList.contains('my-message') &&
+                    !msg.textContent.includes('(기록)'); // 기록 메시지는 제외
             });
 
             if (isDuplicate) {


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #183 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 채팅 REST API 엔드포인트에 Swagger/OpenAPI 설명이 추가되었습니다.

* **버그 수정**
  * 채팅방 목록 조회 시, 참여자 정보를 기반으로 더 정확한 채팅방 목록이 제공됩니다.

* **기타**
  * 메시지 중복 감지 관련 코드의 들여쓰기가 정리되었습니다.  
  * 일부 디버그 로그 메시지 형식이 단순화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->