### PR TITLE
[refactor] 2명의 사용자 모두 채팅방 나갔을 경우에만 DB에서 삭제

### DIFF
--- a/src/main/java/com/back/domain/chat/chat/controller/ChatRestController.java
+++ b/src/main/java/com/back/domain/chat/chat/controller/ChatRestController.java
@@ -41,12 +41,12 @@ public class ChatRestController {
         return new RsData<>("200", "내 채팅방 목록 조회 성공", chatRooms);
     }
 
-    @Operation(summary = "채팅방 삭제")
+    @Operation(summary = "채팅방 나가기")
     @DeleteMapping("/rooms/{chatRoomId}")
-    public RsData<ChatRoomDto> deleteChatRoom(@PathVariable Long chatRoomId) {
-        chatService.deleteChatRoom(chatRoomId);
+    public RsData<ChatRoomDto> leaveChatRoom(@PathVariable Long chatRoomId, Principal principal) {
+        chatService.leaveChatRoom(chatRoomId, principal);
 
-        return new RsData<>("200", "채팅방 삭제 성공");
+        return new RsData<>("200", "채팅방 나가기 성공");
     }
 
 

--- a/src/main/java/com/back/domain/chat/chat/entity/ChatRoom.java
+++ b/src/main/java/com/back/domain/chat/chat/entity/ChatRoom.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Entity
 @NoArgsConstructor
 @Getter
@@ -28,6 +30,14 @@ public class ChatRoom extends BaseEntity {
 
     // 채팅방 이름 (자동 생성 또는 사용자 지정)
     private String roomName;
+    
+    // 메시지와의 관계 설정 (CASCADE로 ChatRoom 삭제 시 Message도 함께 삭제)
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Message> messages;
+    
+    // 참여자와의 관계 설정 (CASCADE로 ChatRoom 삭제 시 RoomParticipant도 함께 삭제)
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoomParticipant> participants;
 
     public ChatRoom(Post post, Member member) {
         this.post = post;

--- a/src/main/java/com/back/domain/chat/chat/repository/RoomParticipantRepository.java
+++ b/src/main/java/com/back/domain/chat/chat/repository/RoomParticipantRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoomParticipantRepository extends JpaRepository<RoomParticipant, Long> {
@@ -13,4 +14,8 @@ public interface RoomParticipantRepository extends JpaRepository<RoomParticipant
     List<RoomParticipant> findByChatRoomPostIdAndMemberIdAndIsActiveTrue(Long postId, Long memberId);
 
     List<RoomParticipant> findByMemberIdAndIsActiveTrueOrderByCreatedAtDesc(Long id);
+
+    Optional<RoomParticipant> findByChatRoomIdAndMemberIdAndIsActiveTrue(Long chatRoomId, Long id);
+
+    boolean existsByChatRoomIdAndIsActiveTrue(Long chatRoomId);
 }


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #220 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 채팅방 나가기 기능이 추가되어, 사용자가 채팅방에서 나갈 수 있습니다. 모든 참가자가 나가면 채팅방이 자동으로 삭제됩니다.

* **버그 수정**
  * 채팅방 삭제 로직이 개선되어, 참가자 기준으로 채팅방이 관리됩니다. 

* **기타**
  * 채팅방과 메시지, 참가자 간의 관계가 강화되어, 채팅방 삭제 시 관련 데이터가 함께 정리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->