### PR TITLE
[refactor] 관리자, 회원 정보 DTO 및 Service 리팩토링

### DIFF
--- a/src/main/java/com/back/domain/admin/dto/request/AdminUpdateMemberRequest.java
+++ b/src/main/java/com/back/domain/admin/dto/request/AdminUpdateMemberRequest.java
@@ -5,6 +5,5 @@ import com.back.domain.member.entity.Status;
 public record AdminUpdateMemberRequest(
         String name,
         Status status,
-        String profileUrl,
-        boolean resetPassword
+        String profileUrl
 ) {}

--- a/src/main/java/com/back/domain/admin/dto/response/AdminMemberResponse.java
+++ b/src/main/java/com/back/domain/admin/dto/response/AdminMemberResponse.java
@@ -12,6 +12,7 @@ public record AdminMemberResponse(
         String profileUrl,
         String status,
         LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
         LocalDateTime deletedAt
 ) {
     public static AdminMemberResponse fromEntity(Member member) {
@@ -23,6 +24,7 @@ public record AdminMemberResponse(
                 member.getProfileUrl(),
                 member.getStatus().name(),
                 member.getCreatedAt(),
+                member.getModifiedAt(),
                 member.getDeletedAt()
         );
     }

--- a/src/main/java/com/back/domain/admin/service/AdminService.java
+++ b/src/main/java/com/back/domain/admin/service/AdminService.java
@@ -2,7 +2,6 @@ package com.back.domain.admin.service;
 
 import com.back.domain.admin.dto.request.AdminUpdateMemberRequest;
 import com.back.domain.admin.dto.response.AdminMemberResponse;
-import com.back.domain.member.dto.response.MemberInfoResponse;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.entity.Role;
 import com.back.domain.member.repository.MemberRepository;
@@ -14,6 +13,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -59,14 +60,12 @@ public class AdminService {
         }
 
         // 3. 프로필 이미지 변경
-        if (request.profileUrl() != null && !request.profileUrl().isBlank()) {
-            member.updateProfileUrl(request.profileUrl());
-        }
-
-        // 4. 비밀번호 초기화
-        if (request.resetPassword()) {
-            member.updatePassword(passwordEncoder.encode("test1234!"));
-        }
+        // 빈 문자열이거나 공백만 있는 경우 null로 설정
+        String profileUrl = Optional.ofNullable(request.profileUrl())
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .orElse(null);
+        member.updateProfileUrl(profileUrl);
 
         memberRepository.save(member);
     }

--- a/src/test/java/com/back/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/back/domain/admin/controller/AdminControllerTest.java
@@ -20,7 +20,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -108,8 +107,7 @@ public class AdminControllerTest {
         AdminUpdateMemberRequest request = new AdminUpdateMemberRequest(
                 "변경된이름",
                 Status.BLOCKED,
-                "https://new.image.url/profile.png",
-                true // 비밀번호 초기화 요청
+                "https://new.image.url/profile.png"
         );
 
         // when
@@ -117,15 +115,13 @@ public class AdminControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value("200"))
-                .andExpect(jsonPath("$.msg").value("회원 정보 수정 성공"));
+                .andExpect(jsonPath("$.resultCode").value("200"));
 
         // then
         Member updated = memberRepository.findById(member.getId()).orElseThrow();
         assertEquals("변경된이름", updated.getName());
         assertEquals(Status.BLOCKED, updated.getStatus());
         assertEquals("https://new.image.url/profile.png", updated.getProfileUrl());
-        assertTrue(passwordEncoder.matches("test1234!", updated.getPassword()));
     }
 
     @Test
@@ -137,8 +133,7 @@ public class AdminControllerTest {
         AdminUpdateMemberRequest request = new AdminUpdateMemberRequest(
                 "아무거나",
                 Status.ACTIVE,
-                null,
-                false
+                null
         );
 
         // when & then

--- a/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/back/domain/auth/controller/AuthControllerTest.java
@@ -357,7 +357,7 @@ public class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.resultCode").value("403"))
+                .andExpect(jsonPath("$.resultCode").value("403-1"))
                 .andExpect(jsonPath("$.msg").value("이메일 또는 비밀번호가 잘못되었습니다."));
     }
 }


### PR DESCRIPTION
## 📢 기능 설명
1. 관리자 회원 정보 수정 및 조회시 사용하는 DTO 필드 내용 수정
2. profileUrl 수정 시, null 들어가도록 Service 수정

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #219 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자 회원 정보 응답에 마지막 수정 시각(`modifiedAt`)이 추가되었습니다.

* **버그 수정**
  * 회원 정보 수정 시 프로필 URL 입력이 공백 또는 빈 문자열이면 프로필 URL이 비워지도록 개선되었습니다.

* **테스트**
  * 비밀번호 재설정 관련 테스트 코드와 검증이 제거되었습니다.
  * 삭제된 사용자의 로그인 실패 테스트에서 반환 코드가 `"403-1"`로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->